### PR TITLE
Increase functional test timeout.

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -20,4 +20,5 @@ jobs:
       python-version-unit: "['3.8', '3.10']"
       python-version-func: "3.10"
       tox-version: "<4"
+      timeout-minutes: 120
       commands: "['FUNC_ARGS=\"--series jammy\" make functional']"


### PR DESCRIPTION
Functional test skipped because of timeout. Double the timeout to see if it works.