### PR TITLE
ci: Switch juju channel to 3.1/stable for functional test on CI

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -21,3 +21,4 @@ jobs:
       python-version-func: "3.10"
       tox-version: "<4"
       commands: "['FUNC_ARGS=\"--series jammy\" make functional']"
+      juju-channel: "3.1/stable"


### PR DESCRIPTION
Depends on: https://github.com/canonical/bootstack-actions/pull/29

We can choose either #34 or this PR.