### PR TITLE
fix(redfish-config): Get redfish host from ipmitool

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -17,11 +17,6 @@ options:
       default, it will set to INFO. Allowed values are "DEBUG", "INFO",
       "WARNING", "ERROR", "CRITICAL". Values other than those will result in
       failure of the exporter.
-  redfish-host:
-    type: string
-    default: "http://127.0.0.1"
-    description: |
-      BMC hostname to be used by the redfish collector.
   redfish-username:
     type: string
     default: ""

--- a/src/hw_tools.py
+++ b/src/hw_tools.py
@@ -306,7 +306,7 @@ def bmc_hw_verifier() -> t.List[HWTool]:
     """
     tools = []
     # Check IPMI available
-    apt.add_package("ipmitool", update_cache=True)
+    apt.add_package("ipmitool", update_cache=False)
     try:
         subprocess.check_output("ipmitool lan print".split())
         tools.append(HWTool.IPMI)

--- a/src/service.py
+++ b/src/service.py
@@ -89,9 +89,9 @@ class ExporterTemplate:
             PORT=port,
             LEVEL=level,
             COLLECTORS=collectors,
-            REDFISH_HOST=redfish_creds["host"],
-            REDFISH_USERNAME=redfish_creds["username"],
-            REDFISH_PASSWORD=redfish_creds["password"],
+            REDFISH_HOST=redfish_creds.get("host"),
+            REDFISH_USERNAME=redfish_creds.get("username"),
+            REDFISH_PASSWORD=redfish_creds.get("password"),
         )
         return self._install(EXPORTER_CONFIG_PATH, content)
 

--- a/tests/functional/test_charm.py
+++ b/tests/functional/test_charm.py
@@ -157,34 +157,6 @@ class TestCharm:
 
         await app.reset_config(["exporter-log-level"])
 
-    async def test_02_config_changed_redfish(self, app, unit, sync_helper, ops_test):
-        """Test changing the config options for redfish credentials."""
-        new_redfish_host = "https://1.2.3.4"
-        new_redfish_username = "testuser"
-        new_redfish_password = "testpassword"
-        await asyncio.gather(
-            app.set_config(
-                {
-                    "redfish-host": new_redfish_host,
-                    "redfish-username": new_redfish_username,
-                    "redfish-password": new_redfish_password,
-                }
-            ),
-            ops_test.model.wait_for_idle(apps=[APP_NAME]),
-        )
-
-        cmd = "cat /etc/hardware-exporter-config.yaml"
-        results = await sync_helper.run_wait(unit, cmd)
-        assert results.get("Code") == "0"
-        config = yaml.safe_load(results.get("Stdout").strip())
-        assert config["redfish-host"] == new_redfish_host
-        assert config["redfish-username"] == new_redfish_username
-        assert config["redfish-password"] == new_redfish_password
-
-        await app.reset_config(["redfish-host"])
-        await app.reset_config(["redfish-username"])
-        await app.reset_config(["redfish-password"])
-
     async def test_10_start_and_stop_exporter(self, app, unit, sync_helper, ops_test):
         """Test starting and stopping the exporter results in correct charm status."""
         # Stop the exporter

--- a/tests/unit/test_exporter.py
+++ b/tests/unit/test_exporter.py
@@ -40,7 +40,9 @@ class TestExporter(unittest.TestCase):
         get_hw_tool_white_list_patcher.start()
         self.addCleanup(get_hw_tool_white_list_patcher.stop)
 
-    def test_00_install_okay(self):
+    @mock.patch("charm.get_bmc_address", return_value="127.0.0.1")
+    @mock.patch("charm.bmc_hw_verifier", return_value=[HWTool.IPMI, HWTool.REDFISH])
+    def test_00_install_okay(self, mock_bmc_hw_verifier, mock_get_bmc_address):
         """Test exporter service is installed when charm is installed - okay."""
         self.harness.begin()
 
@@ -49,7 +51,9 @@ class TestExporter(unittest.TestCase):
             mock_open.assert_called()
             self.mock_systemd.daemon_reload.assert_called_once()
 
-    def test_01_install_failed_rendering(self):
+    @mock.patch("charm.get_bmc_address", return_value="127.0.0.1")
+    @mock.patch("charm.bmc_hw_verifier", return_value=[HWTool.IPMI, HWTool.REDFISH])
+    def test_01_install_failed_rendering(self, mock_bmc_hw_verifier, mock_get_bmc_address):
         """Test exporter service is failed to installed - failed to render."""
         self.harness.begin()
 
@@ -175,8 +179,12 @@ class TestExporter(unittest.TestCase):
             self.harness.charm.unit.status, BlockedStatus("Missing relation: [cos-agent]")
         )
 
+    @mock.patch("charm.get_bmc_address", return_value="127.0.0.1")
+    @mock.patch("charm.bmc_hw_verifier", return_value=[HWTool.IPMI, HWTool.REDFISH])
     @mock.patch.object(pathlib.Path, "exists", return_value=True)
-    def test_60_config_changed_log_level_okay(self, mock_service_installed):
+    def test_60_config_changed_log_level_okay(
+        self, mock_service_installed, mock_bmc_hw_verifier, mock_get_bmc_address
+    ):
         """Test on_config_change function when exporter-log-level is changed."""
         self.harness.begin()
 

--- a/tests/unit/test_hardware.py
+++ b/tests/unit/test_hardware.py
@@ -2,7 +2,7 @@ import subprocess
 import unittest
 from unittest import mock
 
-from hardware import lshw
+from hardware import get_bmc_address, lshw
 
 
 class TestLshw(unittest.TestCase):
@@ -30,3 +30,48 @@ class TestLshw(unittest.TestCase):
     def test_lshw_error_handling(self, mock_subprocess):
         with self.assertRaises(subprocess.CalledProcessError):
             lshw()
+
+
+class TestGetBMCAddress(unittest.TestCase):
+    @mock.patch("hardware.apt")
+    @mock.patch("hardware.subprocess.check_output")
+    def test_get_bmc_address(self, mock_check_output, mock_apt):
+        mock_check_output.return_value = """
+            Set in Progress         : Set Complete
+            Auth Type Support       : NONE MD5 PASSWORD
+            Auth Type Enable        : Callback : MD5 PASSWORD
+                                    : User     : MD5 PASSWORD
+                                    : Operator : MD5 PASSWORD
+                                    : Admin    : MD5 PASSWORD
+                                    : OEM      :
+            IP Address Source		: Static Address
+            IP Address              : 10.244.120.100
+            Subnet Mask             : 255.255.252.0
+            MAC Address             : 5a:ba:3c:3b:b4:59
+            SNMP Community String   :
+            BMC ARP Control         : ARP Responses Enabled, Gratuitous ARP Disabled
+            Default Gateway IP      : 10.240.128.1
+            802.1q VLAN ID          : Disabled
+            802.1q VLAN Priority    : 0
+            RMCP+ Cipher Suites     : 0,1,2,3
+            Cipher Suite Priv Max   : XXXaXXXXXXXXXXX
+                                    :     X=Cipher Suite Unused
+                                    :     c=CALLBACK
+                                    :     u=USER
+                                    :     o=OPERATOR
+                                    :     a=ADMIN
+                                    :     O=OEM
+            Bad Password Threshold  : Not Available
+            """.strip()
+
+        output = get_bmc_address()
+        self.assertEqual(output, "10.244.120.100")
+
+    @mock.patch("hardware.apt")
+    @mock.patch(
+        "hardware.subprocess.check_output",
+        side_effect=subprocess.CalledProcessError(-1, "cmd"),
+    )
+    def test_get_bmc_address_error_handling(self, mock_subprocess, mock_apt):
+        output = get_bmc_address()
+        self.assertEqual(output, None)

--- a/tests/unit/test_hw_tools.py
+++ b/tests/unit/test_hw_tools.py
@@ -555,7 +555,7 @@ class TestIPMIHWVerifier(unittest.TestCase):
     @mock.patch("hw_tools.apt")
     def test_bmc_hw_verifier(self, mock_apt, mock_subprocess, mock_redfish_discover_ssdp):
         output = bmc_hw_verifier()
-        mock_apt.add_package.assert_called_with("ipmitool", update_cache=True)
+        mock_apt.add_package.assert_called_with("ipmitool", update_cache=False)
         mock_subprocess.check_output.assert_called_with("ipmitool lan print".split())
         self.assertCountEqual(output, [HWTool.IPMI, HWTool.REDFISH])
         mock_redfish_discover_ssdp.assert_called()
@@ -570,6 +570,6 @@ class TestIPMIHWVerifier(unittest.TestCase):
         self, mock_apt, mock_check_output, mock_redfish_discover_ssdp
     ):
         output = bmc_hw_verifier()
-        mock_apt.add_package.assert_called_with("ipmitool", update_cache=True)
+        mock_apt.add_package.assert_called_with("ipmitool", update_cache=False)
         mock_check_output.assert_called_with("ipmitool lan print".split())
         self.assertEqual(output, [])


### PR DESCRIPTION
- The redfish host will be different for each machine and it shouldn't be provided by juju config
- Force user to use https protocol for RedFish.