### PR TITLE
Add quotes around keys in exporter config template

### DIFF
--- a/templates/hardware-exporter-config.yaml.j2
+++ b/templates/hardware-exporter-config.yaml.j2
@@ -8,7 +8,7 @@ enable_collectors:
 {% endif %}
 
 {% if REDFISH_ENABLE  %}
-redfish_host: {{ REDFISH_HOST }}
-redfish_username: {{ REDFISH_USERNAME }}
-redfish_password: {{ REDFISH_PASSWORD }}
+redfish_host: "{{ REDFISH_HOST }}"
+redfish_username: "{{ REDFISH_USERNAME }}"
+redfish_password: "{{ REDFISH_PASSWORD }}"
 {% endif %}


### PR DESCRIPTION
These quotes are added to fix the pydantic error caused while reading the yaml file. If the quotes are absent for the redfish keys, the default value of empty string is registered as a None type while using safe_load and reading the yaml file in prometheus-hardware-exporter.

Fixes #43