### PR TITLE
Drop bionic support

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -24,7 +24,3 @@ bases:
         channel: "20.04"
         architectures:
           - amd64
-      - name: ubuntu
-        channel: "18.04"
-        architectures:
-          - amd64


### PR DESCRIPTION
Since operator library assumes python >= 3.8 [1], this charm should not be installed on ubuntu bionic and below.

[1] https://github.com/canonical/operator/blob/2.2.0/setup.py#L75

Closes: #88 