### PR TITLE
fix(alert): Ignore IPMI slot connector alerts.

### DIFF
--- a/src/prometheus_alert_rules/ipmi_sensors.yaml
+++ b/src/prometheus_alert_rules/ipmi_sensors.yaml
@@ -75,13 +75,13 @@ groups:
             LABELS = {{ $labels }}
 
     - alert: IPMISensorStateNotOk
-      expr: ipmi_generic_sensor_value{state=~"Warning|Critical", type!="Entity Presence"}
+      expr: ipmi_generic_sensor_value{state=~"Warning|Critical", type!="Entity Presence", type!="Slot/Connector"}
       for: 0m
-      labels: 
+      labels:
         severity: "{{ toLower $labels.state }}"
       annotations:
         summary: IPMI sensor value in {{ toLower $labels.state }} state. (instance {{ $labels.instance }})
         description: |
-          A sensor value, recorded by ipmi sensor, in {{ toLower $labels.state }} state. Entity Presence sensors are ignored.
+          A sensor value, recorded by ipmi sensor, in {{ toLower $labels.state }} state. Entity Presence and Slot Connector sensors are ignored.
             VALUE = {{ $value }}
             LABELS = {{ $labels }}

--- a/tests/unit/test_alert_rules/test_ipmi_sensors.yaml
+++ b/tests/unit/test_alert_rules/test_ipmi_sensors.yaml
@@ -228,7 +228,7 @@ tests:
             exp_annotations:
               summary: IPMI sensor value in warning state. (instance ubuntu-11)
               description: |
-                A sensor value, recorded by ipmi sensor, in warning state. Entity Presence sensors are ignored.
+                A sensor value, recorded by ipmi sensor, in warning state. Entity Presence and Slot Connector sensors are ignored.
                   VALUE = 20
                   LABELS = map[__name__:ipmi_generic_sensor_value instance:ubuntu-11 state:Warning]
           - exp_labels:
@@ -238,6 +238,6 @@ tests:
             exp_annotations:
               summary: IPMI sensor value in critical state. (instance ubuntu-12)
               description: |
-                A sensor value, recorded by ipmi sensor, in critical state. Entity Presence sensors are ignored.
+                A sensor value, recorded by ipmi sensor, in critical state. Entity Presence and Slot Connector sensors are ignored.
                   VALUE = 50
                   LABELS = map[__name__:ipmi_generic_sensor_value instance:ubuntu-12 state:Critical]


### PR DESCRIPTION
Fixes: #107

Similar to https://github.com/canonical/hardware-observer-operator/pull/101