### PR TITLE
refactor: Fix alert rules for failed collector.

### DIFF
--- a/tests/functional/test_charm.py
+++ b/tests/functional/test_charm.py
@@ -14,6 +14,7 @@ import yaml
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
+pytestmark = pytest.mark.asyncio(scope="module")
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]

--- a/tests/functional/test_charm.py
+++ b/tests/functional/test_charm.py
@@ -14,7 +14,6 @@ import yaml
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
-pytestmark = pytest.mark.asyncio(scope="module")
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]

--- a/tests/unit/test_alert_rules/test_general.yaml
+++ b/tests/unit/test_alert_rules/test_general.yaml
@@ -6,9 +6,9 @@ evaluation_interval: 1m
 tests:
   - interval: 1m
     input_series:
-      - series: ipmidcmicollector_collector_failed{instance="ubuntu-99", collector="IPMIDCMICollector"}
+      - series: ipmidcmi_collector_failed{instance="ubuntu-99", collector="ipmidcmi"}
         values: '1x15'
-      - series: ipmiselcollector_collector_failed{instance="ubuntu-99", collector="IPMISELCollector"}
+      - series: ipmisel_collector_failed{instance="ubuntu-99", collector="ipmisel"}
         values: '1x15'
 
     alert_rule_test:
@@ -18,18 +18,18 @@ tests:
           - exp_labels:
               severity: error
               instance: ubuntu-99
-              collector: IPMIDCMICollector
+              collector: ipmidcmi
             exp_annotations:
               summary: Collector failed. (instance ubuntu-99)
               description: |
                 A collector failed to fetch the metrics. Please reach out to hardware-observer maintainers.
-                  LABELS = map[__name__:ipmidcmicollector_collector_failed collector:IPMIDCMICollector instance:ubuntu-99]
+                  LABELS = map[__name__:ipmidcmi_collector_failed collector:ipmidcmi instance:ubuntu-99]
           - exp_labels:
               severity: error
               instance: ubuntu-99
-              collector: IPMISELCollector
+              collector: ipmisel
             exp_annotations:
               summary: Collector failed. (instance ubuntu-99)
               description: |
                 A collector failed to fetch the metrics. Please reach out to hardware-observer maintainers.
-                  LABELS = map[__name__:ipmiselcollector_collector_failed collector:IPMISELCollector instance:ubuntu-99]
+                  LABELS = map[__name__:ipmisel_collector_failed collector:ipmisel instance:ubuntu-99]


### PR DESCRIPTION
Relates to https://github.com/canonical/prometheus-hardware-exporter/pull/54