### PR TITLE
feat: Add redfish alert rules for null health.

### DIFF
--- a/src/prometheus_alert_rules/redfish.yaml
+++ b/src/prometheus_alert_rules/redfish.yaml
@@ -26,7 +26,7 @@ groups:
               LABELS = {{ $labels }}
 
       - alert: RedfishSensorHealthNotOk
-        expr: redfish_sensor_info{health != "OK"}
+        expr: redfish_sensor_info{health!~"OK|N/A"}
         for: 0m
         labels:
           severity: critical
@@ -37,8 +37,20 @@ groups:
               SENSOR_READING = {{ $labels.reading }}
               LABELS = {{ $labels }}
 
+      - alert: RedfishSensorHealthNotAvailable
+        expr: redfish_sensor_info{health="N/A"}
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: Redfish sensor health not available. (instance {{ $labels.instance }})
+          description: |
+            Redfish sensor health not available.
+              SENSOR_READING = {{ $labels.reading }}
+              LABELS = {{ $labels }}
+
       - alert: RedfishProcessorHealthNotOk
-        expr: redfish_processor_info{health != "OK"}
+        expr: redfish_processor_info{health!~"OK|NA"}
         for: 0m
         labels:
           severity: critical
@@ -48,8 +60,19 @@ groups:
             Redfish processor health not OK.
               LABELS = {{ $labels }}
 
+      - alert: RedfishProcessorHealthNotAvailable
+        expr: redfish_processor_info{health="NA"}
+        for: 0m
+        labels:
+          severity: warning 
+        annotations:
+          summary: Redfish processor health not available. (instance {{ $labels.instance }})
+          description: |
+            Redfish processor health not available.
+              LABELS = {{ $labels }}
+
       - alert: RedfishStorageControllerHealthNotOk
-        expr: redfish_storage_controller_info{health != "OK"}
+        expr: redfish_storage_controller_info{health!~"OK|NA"}
         for: 0m
         labels:
           severity: critical
@@ -59,8 +82,19 @@ groups:
             Redfish storage controller health not OK.
               LABELS = {{ $labels }}
 
+      - alert: RedfishStorageControllerHealthNotAvailable
+        expr: redfish_storage_controller_info{health="NA"}
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: Redfish storage controller health not available. (instance {{ $labels.instance }})
+          description: |
+            Redfish storage controller health not available.
+              LABELS = {{ $labels }}
+
       - alert: RedfishChassisHealthNotOk
-        expr: redfish_chassis_info{health != "OK"}
+        expr: redfish_chassis_info{health!~"OK|NA"}
         for: 0m
         labels:
           severity: critical
@@ -70,8 +104,19 @@ groups:
             Redfish chassis health not OK.
               LABELS = {{ $labels }}
 
+      - alert: RedfishChassisHealthNotAvailable
+        expr: redfish_chassis_info{health="NA"}
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: Redfish chassis health not available. (instance {{ $labels.instance }})
+          description: |
+            Redfish chassis health not available.
+              LABELS = {{ $labels }}
+
       - alert: RedfishStorageDriveHealthNotOk
-        expr: redfish_storage_drive_info{health != "OK"}
+        expr: redfish_storage_drive_info{health!~"OK|NA"}
         for: 0m
         labels:
           severity: critical
@@ -81,8 +126,19 @@ groups:
             Redfish storage drive health not OK.
               LABELS = {{ $labels }}
 
+      - alert: RedfishStorageDriveHealthNotAvailable
+        expr: redfish_storage_drive_info{health="NA"}
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: Redfish storage drive health not available. (instance {{ $labels.instance }})
+          description: |
+            Redfish storage drive health not available.
+              LABELS = {{ $labels }}
+
       - alert: RedfishMemoryDimmHealthNotOk
-        expr: redfish_memory_dimm_info{health != "OK"}
+        expr: redfish_memory_dimm_info{health!~"OK|NA"}
         for: 0m
         labels:
           severity: critical
@@ -90,6 +146,17 @@ groups:
           summary: Redfish memory dimm health not OK. (instance {{ $labels.instance }})
           description: |
             Redfish memory dimm health not OK.
+              LABELS = {{ $labels }}
+
+      - alert: RedfishMemoryDimmHealthNotAvailable
+        expr: redfish_memory_dimm_info{health="NA"}
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: Redfish memory dimm health not available. (instance {{ $labels.instance }})
+          description: |
+            Redfish memory dimm health not available.
               LABELS = {{ $labels }}
 
       - alert: RedfishSmartStorageHealthNotOk

--- a/tests/functional/requirements.txt
+++ b/tests/functional/requirements.txt
@@ -1,2 +1,5 @@
 pytest
 pytest-operator
+# Keep protobuf < 4.0 until macaroonbakery solves its incompatibility
+# https://github.com/go-macaroon-bakery/py-macaroon-bakery/issues/94
+protobuf<4.0

--- a/tests/unit/test_alert_rules/test_redfish.yaml
+++ b/tests/unit/test_alert_rules/test_redfish.yaml
@@ -65,6 +65,27 @@ tests:
 
   - interval: 1m
     input_series:
+      - series: redfish_sensor_info{instance="ubuntu-2", health="N/A", reading="N/A"}
+        values: "1x15"
+
+    alert_rule_test:
+      - eval_time: 0m
+        alertname: RedfishSensorHealthNotAvailable
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: ubuntu-2
+              health: N/A
+              reading: N/A
+            exp_annotations:
+              summary: Redfish sensor health not available. (instance ubuntu-2)
+              description: |
+                Redfish sensor health not available.
+                  SENSOR_READING = N/A
+                  LABELS = map[__name__:redfish_sensor_info health:N/A instance:ubuntu-2 reading:N/A]
+
+  - interval: 1m
+    input_series:
       - series: redfish_processor_info{instance="ubuntu-1", health="Unhealthy", system_id="s1", processor_id="p1", model="processor-model-1"}
         values: "1x15"
 
@@ -84,6 +105,28 @@ tests:
               description: |
                 Redfish processor health not OK.
                   LABELS = map[__name__:redfish_processor_info health:Unhealthy instance:ubuntu-1 model:processor-model-1 processor_id:p1 system_id:s1]
+
+  - interval: 1m
+    input_series:
+      - series: redfish_processor_info{instance="ubuntu-1", health="NA", system_id="s1", processor_id="p1", model="processor-model-1"}
+        values: "1x15"
+
+    alert_rule_test:
+      - eval_time: 0m
+        alertname: RedfishProcessorHealthNotAvailable
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: ubuntu-1
+              health: NA 
+              system_id: s1
+              processor_id: p1
+              model: processor-model-1
+            exp_annotations:
+              summary: Redfish processor health not available. (instance ubuntu-1)
+              description: |
+                Redfish processor health not available.
+                  LABELS = map[__name__:redfish_processor_info health:NA instance:ubuntu-1 model:processor-model-1 processor_id:p1 system_id:s1]
 
   - interval: 1m
     input_series:
@@ -109,6 +152,28 @@ tests:
 
   - interval: 1m
     input_series:
+      - series: redfish_storage_controller_info{instance="ubuntu-1", health="NA", system_id="s1", storage_id="stor1", controller_id="ctrl1"}
+        values: "1x15"
+
+    alert_rule_test:
+      - eval_time: 0m
+        alertname: RedfishStorageControllerHealthNotAvailable
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: ubuntu-1
+              health: NA
+              system_id: s1
+              storage_id: stor1
+              controller_id: ctrl1
+            exp_annotations:
+              summary: Redfish storage controller health not available. (instance ubuntu-1)
+              description: |
+                Redfish storage controller health not available.
+                  LABELS = map[__name__:redfish_storage_controller_info controller_id:ctrl1 health:NA instance:ubuntu-1 storage_id:stor1 system_id:s1]
+
+  - interval: 1m
+    input_series:
       - series: redfish_chassis_info{instance="ubuntu-1", health="Unhealthy", chassis_id="ch1", model="chassis-model1"}
         values: "1x15"
 
@@ -127,6 +192,27 @@ tests:
               description: |
                 Redfish chassis health not OK.
                   LABELS = map[__name__:redfish_chassis_info chassis_id:ch1 health:Unhealthy instance:ubuntu-1 model:chassis-model1]
+
+  - interval: 1m
+    input_series:
+      - series: redfish_chassis_info{instance="ubuntu-1", health="NA", chassis_id="ch1", model="chassis-model1"}
+        values: "1x15"
+
+    alert_rule_test:
+      - eval_time: 0m
+        alertname: RedfishChassisHealthNotAvailable
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: ubuntu-1
+              health: NA
+              chassis_id: ch1
+              model: chassis-model1
+            exp_annotations:
+              summary: Redfish chassis health not available. (instance ubuntu-1)
+              description: |
+                Redfish chassis health not available.
+                  LABELS = map[__name__:redfish_chassis_info chassis_id:ch1 health:NA instance:ubuntu-1 model:chassis-model1]
 
   - interval: 1m
     input_series:
@@ -152,6 +238,28 @@ tests:
 
   - interval: 1m
     input_series:
+      - series: redfish_storage_drive_info{instance="ubuntu-1", health="NA", system_id="s1", storage_id="stor1", drive_id="dr1"}
+        values: "1x15"
+
+    alert_rule_test:
+      - eval_time: 0m
+        alertname: RedfishStorageDriveHealthNotAvailable
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: ubuntu-1
+              health: NA
+              system_id: s1
+              storage_id: stor1
+              drive_id: dr1
+            exp_annotations:
+              summary: Redfish storage drive health not available. (instance ubuntu-1)
+              description: |
+                Redfish storage drive health not available.
+                  LABELS = map[__name__:redfish_storage_drive_info drive_id:dr1 health:NA instance:ubuntu-1 storage_id:stor1 system_id:s1]
+
+  - interval: 1m
+    input_series:
       - series: redfish_memory_dimm_info{instance="ubuntu-1", health="Unhealthy", system_id="s1", memory_id="mem1"}
         values: "1x15"
 
@@ -170,6 +278,27 @@ tests:
               description: |
                 Redfish memory dimm health not OK.
                   LABELS = map[__name__:redfish_memory_dimm_info health:Unhealthy instance:ubuntu-1 memory_id:mem1 system_id:s1]
+
+  - interval: 1m
+    input_series:
+      - series: redfish_memory_dimm_info{instance="ubuntu-1", health="NA", system_id="s1", memory_id="mem1"}
+        values: "1x15"
+
+    alert_rule_test:
+      - eval_time: 0m
+        alertname: RedfishMemoryDimmHealthNotAvailable
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: ubuntu-1
+              health: NA
+              system_id: s1
+              memory_id: mem1
+            exp_annotations:
+              summary: Redfish memory dimm health not available. (instance ubuntu-1)
+              description: |
+                Redfish memory dimm health not available.
+                  LABELS = map[__name__:redfish_memory_dimm_info health:NA instance:ubuntu-1 memory_id:mem1 system_id:s1]
 
   - interval: 1m
     input_series:


### PR DESCRIPTION
Add new alert rules with lower severity (warning) for when the health data isn't present and set with either "NA" or "N/A".

This prevents diluting the real critical health related alerts when the health data isn't available.

Resolves #113, #112, #129 