### PR TITLE
feat: Add promtool testing in Makefile

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -19,6 +19,21 @@ jobs:
     with:
       python-version: ${{ matrix.python-version }}
       tox-version: "<4"
+  
+  promtool:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      # prometheus snap comes pre-packaged with promtool
+      - name: Install prometheus snap
+        run: sudo snap install prometheus
+      - name: Check validity of prometheus alert rules
+        run: |
+          promtool check rules src/prometheus_alert_rules/*.yaml
+      - name: Run unit tests for prometheus alert rules 
+        run: |
+          promtool test rules tests/unit/test_alert_rules/*.yaml
 
   func:
     uses: canonical/bootstack-actions/.github/workflows/func.yaml@v2

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -37,7 +37,7 @@ jobs:
 
   func:
     uses: canonical/bootstack-actions/.github/workflows/func.yaml@v2
-    needs: lint-unit
+    needs: [lint-unit, promtool]
     strategy:
       fail-fast: false
       matrix:

--- a/Makefile
+++ b/Makefile
@@ -72,9 +72,15 @@ reformat:
 	@echo "Reformat files with black and isort"
 	@tox -e reformat
 
-unittests:
+install-prom:
+	@echo "Installing prometheus snap which comes pre-packaged with promtool"
+	@sudo snap install prometheus
+
+unittests: install-prom
 	@echo "Running unit tests"
 	@tox -e unit -- ${UNIT_ARGS}
+	@echo "\nRunning promtool based unit tests for alert rules"
+	@promtool test rules ${PROJECTPATH}/tests/unit/test_alert_rules/*.yaml
 
 functional: 
 	@echo "Executing functional tests using built charm at ${PROJECTPATH}"

--- a/Makefile
+++ b/Makefile
@@ -72,15 +72,9 @@ reformat:
 	@echo "Reformat files with black and isort"
 	@tox -e reformat
 
-install-prom:
-	@echo "Installing prometheus snap which comes pre-packaged with promtool"
-	@sudo snap install prometheus
-
-unittests: install-prom
+unittests:
 	@echo "Running unit tests"
 	@tox -e unit -- ${UNIT_ARGS}
-	@echo "\nRunning promtool based unit tests for alert rules"
-	@promtool test rules ${PROJECTPATH}/tests/unit/test_alert_rules/*.yaml
 
 functional: 
 	@echo "Executing functional tests using built charm at ${PROJECTPATH}"

--- a/tests/unit/test_alert_rules/test_lsi_sas.yaml
+++ b/tests/unit/test_alert_rules/test_lsi_sas.yaml
@@ -1,5 +1,5 @@
 rule_files:
-  - ../../../src/prometheus_alert_rules/lsi_sas_2.yaml
+  - ../../../src/prometheus_alert_rules/lsi_sas.yaml
 
 evaluation_interval: 1m
 


### PR DESCRIPTION
This change adds another job in the `check.yaml` workflow to install the prometheus snap (which comes with promtool) and runs validation and unit tests on the alert rules using promtool.

Also fixes a typo in an alert rule test.

Resolves #3 