### PR TITLE
test: Fix failed functional test

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -118,6 +118,11 @@ class HardwareObserverCharm(ops.CharmBase):
             self.model.unit.status = BlockedStatus("Cannot relate to more than one grafana-agent")
             return
 
+        config_valied, confg_valid_message = self.validate_exporter_configs()
+        if not config_valied:
+            self.model.unit.status = BlockedStatus(confg_valid_message)
+            return
+
         hw_tool_ok, error_msg = self.hw_tool_helper.check_installed()
         if not hw_tool_ok:
             self.model.unit.status = BlockedStatus(error_msg)


### PR DESCRIPTION
Fix failure functional test caused because of life-cycle changing.

- Config check be checked on update_status hook to avoid overwriting status.
- The exporter failed test doesn't make sense anymore because the exporter should able to auto-recover by itself. Change the logic to see if the exporter is able to auto-restart or not.
- Update error message validation.