### PR TITLE
fix: Change default port for prometheus exporter

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5,10 +5,10 @@
 options:
   exporter-port:
     type: int
-    default: 10000
+    default: 10200
     description: |
       Start the prometheus exporter at "exporter-port". By default, it will
-      start at port 10000.
+      start at port 10200.
   exporter-log-level:
     type: string
     default: "INFO"

--- a/src/apt_helpers.py
+++ b/src/apt_helpers.py
@@ -1,4 +1,5 @@
 """Apt helper module for missing features in operator_libs_linux."""
+
 import re
 from subprocess import PIPE, CalledProcessError, check_output
 from typing import Optional

--- a/src/charm.py
+++ b/src/charm.py
@@ -77,7 +77,7 @@ class HardwareObserverCharm(ops.CharmBase):
             self.model.unit.status = BlockedStatus(err_msg)
             return
 
-        port = self.model.config.get("exporter-port", "10000")
+        port = self.model.config.get("exporter-port", "10200")
         level = self.model.config.get("exporter-log-level", "INFO")
         redfish_creds = self._get_redfish_creds()
         success = self.exporter.install(port, level, redfish_creds)
@@ -197,7 +197,7 @@ class HardwareObserverCharm(ops.CharmBase):
             }
             if exporter_configs.intersection(change_set):
                 logger.info("Detected changes in exporter config.")
-                port = self.model.config.get("exporter-port", "10000")
+                port = self.model.config.get("exporter-port", "10200")
                 level = self.model.config.get("exporter-log-level", "INFO")
 
                 redfish_creds = self._get_redfish_creds()
@@ -253,7 +253,7 @@ class HardwareObserverCharm(ops.CharmBase):
 
     def validate_exporter_configs(self) -> Tuple[bool, str]:
         """Validate the static and runtime config options for the exporter."""
-        port = int(self.model.config.get("exporter-port", "10000"))
+        port = int(self.model.config.get("exporter-port", "10200"))
         if not 1 <= port <= 65535:
             logger.error("Invalid exporter-port: port must be in [1, 65535].")
             return False, "Invalid config: 'exporter-port'"

--- a/src/config.py
+++ b/src/config.py
@@ -1,4 +1,5 @@
 """Config."""
+
 import typing as t
 from enum import Enum
 from pathlib import Path

--- a/src/hardware.py
+++ b/src/hardware.py
@@ -1,4 +1,5 @@
 """Hardware support config and command helper."""
+
 import json
 import logging
 import subprocess

--- a/src/hw_tools.py
+++ b/src/hw_tools.py
@@ -2,6 +2,7 @@
 
 Define strategy for install, remove and verifier for different hardwares.
 """
+
 import logging
 import os
 import shutil

--- a/src/service.py
+++ b/src/service.py
@@ -1,4 +1,5 @@
 """Exporter service helper."""
+
 from functools import wraps
 from logging import getLogger
 from pathlib import Path

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -119,7 +119,7 @@ class TestCharm(unittest.TestCase):
 
         self.assertTrue(self.harness.charm._stored.resource_installed)
 
-        self.harness.charm.exporter.install.assert_called_with(10000, "INFO", {})
+        self.harness.charm.exporter.install.assert_called_with(10200, "INFO", {})
 
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())

--- a/tests/unit/test_exporter.py
+++ b/tests/unit/test_exporter.py
@@ -271,7 +271,7 @@ class TestExporter(unittest.TestCase):
             self.harness.add_relation_unit(rid, "grafana-agent/0")
             # self.harness.charm.validate_exporter_configs = mock.Mock()
             # self.harness.charm.validate_exporter_configs.return_value = (False, "error")
-            self.harness.update_config({"exporter-port": 100000, "exporter-log-level": "DEBUG"})
+            self.harness.update_config({"exporter-port": 102000, "exporter-log-level": "DEBUG"})
             self.harness.charm.on.config_changed.emit()
             self.assertEqual(
                 self.harness.charm.unit.status, BlockedStatus("Invalid config: 'exporter-port'")


### PR DESCRIPTION
Change default port for prometheus-exporter from 10000 to 10200 in order to avoid collisions with the same default port in juju-backup-all.

Fixes #133 