### PR TITLE
refactor: Add constant for default exporter port

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -25,6 +25,7 @@ class HardwareObserverCharm(ops.CharmBase):
     """Charm the application."""
 
     _stored = StoredState()
+    DEFAULT_EXPORTER_PORT = "10200"
 
     def __init__(self, *args: Any) -> None:
         """Init."""
@@ -81,7 +82,7 @@ class HardwareObserverCharm(ops.CharmBase):
             self.model.unit.status = BlockedStatus(err_msg)
             return
 
-        port = self.model.config.get("exporter-port", "10200")
+        port = self.model.config.get("exporter-port", self.DEFAULT_EXPORTER_PORT)
         level = self.model.config.get("exporter-log-level", "INFO")
         redfish_creds = self._get_redfish_creds()
         success = self.exporter.install(port, level, redfish_creds)
@@ -201,7 +202,7 @@ class HardwareObserverCharm(ops.CharmBase):
             }
             if exporter_configs.intersection(change_set):
                 logger.info("Detected changes in exporter config.")
-                port = self.model.config.get("exporter-port", "10200")
+                port = self.model.config.get("exporter-port", self.DEFAULT_EXPORTER_PORT)
                 level = self.model.config.get("exporter-log-level", "INFO")
 
                 redfish_creds = self._get_redfish_creds()
@@ -257,7 +258,7 @@ class HardwareObserverCharm(ops.CharmBase):
 
     def validate_exporter_configs(self) -> Tuple[bool, str]:
         """Validate the static and runtime config options for the exporter."""
-        port = int(self.model.config.get("exporter-port", "10200"))
+        port = int(self.model.config.get("exporter-port", self.DEFAULT_EXPORTER_PORT))
         if not 1 <= port <= 65535:
             logger.error("Invalid exporter-port: port must be in [1, 65535].")
             return False, "Invalid config: 'exporter-port'"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -120,7 +120,9 @@ class TestCharm(unittest.TestCase):
 
         self.assertTrue(self.harness.charm._stored.resource_installed)
 
-        self.harness.charm.exporter.install.assert_called_with(10200, "INFO", {})
+        self.harness.charm.exporter.install.assert_called_with(
+            int(self.harness.charm.DEFAULT_EXPORTER_PORT), "INFO", {}
+        )
 
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())


### PR DESCRIPTION
As per suggestion in [this comment](https://github.com/canonical/hardware-observer-operator/pull/153#discussion_r1469370199).

Note: The default port is duplicated in both `src/charm.py` (in the `self.model.config.get` calls) and `config.yaml`. Technically, we just need one -- eg: provide default value in `config.yaml` and call `self.model.config.get` without any default. I'm leaving it as is for now.