### PR TITLE
feat: Add option to provide collectors for hardware dependent tests

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -3,8 +3,6 @@ import logging
 import pytest
 from async_lru import alru_cache
 
-from charm import HardwareObserverCharm
-
 log = logging.getLogger(__name__)
 
 
@@ -25,7 +23,7 @@ class SyncHelper:
     @alru_cache
     async def get_metrics_output(ops_test, unit_name):
         """Return prometheus metric output from endpoint on unit."""
-        port = HardwareObserverCharm.DEFAULT_EXPORTER_PORT
+        port = 10200
         command = f"curl localhost:{port}"
         results = await SyncHelper.run_command_on_unit(ops_test, unit_name, command)
         return results
@@ -55,7 +53,7 @@ def pytest_addoption(parser):
             "lsi_sas_2",
             "lsi_sas_3",
         ],
-        help="Provide space-separated collectors for testing with real hardware.",
+        help="Provide space-separated list of collectors for testing with real hardware.",
     )
 
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,6 +1,9 @@
 import logging
 
 import pytest
+from async_lru import alru_cache
+
+from charm import HardwareObserverCharm
 
 log = logging.getLogger(__name__)
 
@@ -18,6 +21,15 @@ class SyncHelper:
         }
         return results
 
+    @staticmethod
+    @alru_cache
+    async def get_metrics_output(ops_test, unit_name):
+        """Return prometheus metric output from endpoint on unit."""
+        port = HardwareObserverCharm.DEFAULT_EXPORTER_PORT
+        command = f"curl localhost:{port}"
+        results = await SyncHelper.run_command_on_unit(ops_test, unit_name, command)
+        return results
+
 
 def pytest_addoption(parser):
     parser.addoption(
@@ -28,10 +40,49 @@ def pytest_addoption(parser):
         help="Set series for the machine units",
     )
 
+    parser.addoption(
+        "--collectors",
+        nargs="+",
+        type=str.lower,
+        default="",
+        choices=[
+            "ipmi_dcmi",
+            "ipmi_sel",
+            "ipmi_sensor",
+            "redfish",
+            "mega_raid",
+            "poweredge_raid",
+            "lsi_sas_2",
+            "lsi_sas_3",
+        ],
+        help="Provide space-separated collectors for testing with real hardware.",
+    )
+
 
 @pytest.fixture(scope="module")
 def series(request):
     return request.config.getoption("--series")
+
+
+@pytest.fixture(scope="module")
+def provided_collectors(request):
+    return request.config.getoption("collectors")
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "realhw: mark test as requiring real hardware to run.")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("collectors"):
+        # --collectors provided, do not skip tests
+        return
+    skip_real_hw = pytest.mark.skip(
+        reason="Hardware dependent test. Provide collectors with the --collectors option."
+    )
+    for item in items:
+        if "realhw" in item.keywords:
+            item.add_marker(skip_real_hw)
 
 
 @pytest.fixture(scope="module")

--- a/tests/functional/requirements.txt
+++ b/tests/functional/requirements.txt
@@ -1,3 +1,4 @@
+async-lru
 pytest
 pytest-operator
 # Keep protobuf < 4.0 until macaroonbakery solves its incompatibility

--- a/tests/functional/test_charm.py
+++ b/tests/functional/test_charm.py
@@ -6,8 +6,12 @@ import asyncio
 import inspect
 import logging
 import os
+import re
+from collections import defaultdict
+from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
+from typing import Optional
 
 import pytest
 import yaml
@@ -23,10 +27,114 @@ GRAFANA_AGENT_APP_NAME = "grafana-agent"
 TIMEOUT = 600
 
 
+@dataclass
+class Metric:
+    """Class for metric data."""
+
+    name: str
+    labels: Optional[str]
+    value: float
+
+
 def get_this_script_dir() -> Path:
     filename = inspect.getframeinfo(inspect.currentframe()).filename  # type: ignore[arg-type]
     path = os.path.dirname(os.path.abspath(filename))
     return Path(path)
+
+
+def _parse_single_metric(metric: str) -> Optional[Metric]:
+    """Return a Metric object parsed from a single metric string."""
+    # ignore blank lines or comments
+    if not metric or metric.startswith("#"):
+        return None
+
+    # The regex pattern below uses named capturing groups to extract aspects of the metric.
+    # (?P<name>[^\s{]+) captures the metric name and matches one or more chars that are not
+    # whitespace or opening curly brace '{'
+
+    # (?:{(?P<label>[^}]*)})? handles optional labels It uses a non-capturing group (?:...)
+    # to make the entire portion optional. Inside this group:
+    #   {               : Matches an opening curly brace.
+    #   (?P<label>[^}]*): Another named capturing group (label) that matches zero or more
+    #                     characters that are not a closing curly brace ([^}]*).
+    #   }               : Matches a closing curly brace.
+
+    # (?P<value>\d+\.\d+|\d+): This part captures the numeric value.
+    # It uses a named capturing group (value) and matches either:
+    #   \d+\.\d+  : For obtaining floating point values containing a dot.
+    #   |\d+      : OR, one or more digits for integer values.
+
+    pattern = re.compile(r"(?P<name>[^\s{]+)(?:\{(?P<labels>[^}]*)\})?\s+(?P<value>\d+\.\d+|\d+)")
+    match = pattern.match(metric)
+
+    if match:
+        name = match.group("name")
+        labels = match.group("labels") or None
+        value = float(match.group("value"))
+        return Metric(name=name, labels=labels, value=value)
+    else:
+        return None
+
+
+def parse_metrics(metrics_input: str) -> dict[str, list[Metric]]:
+    """Parse raw metrics and return dictionary of parsed Metric objects for each collector.
+
+    For example, parsing this metrics_input,
+        # HELP ipmi_temperature_celsius Temperature measure from temperature sensors
+        # TYPE ipmi_temperature_celsius gauge
+        ipmi_temperature_celsius{name="Exhaust Temp",state="Nominal",unit="C"} 52.0
+
+        # HELP ipmi_power_watts Power measure from power sensors
+        # TYPE ipmi_power_watts gauge
+        ipmi_power_watts{name="Sys Fan Pwr",state="Nominal",unit="W"} 20.0
+
+        # HELP megaraid_virtual_drives Number of virtual drives
+        # TYPE megaraid_virtual_drives gauge
+        megaraid_virtual_drives{controller_id="0"} 1.0
+
+        # HELP redfish_call_success Indicates if call to the redfish API succeeded or not.
+        # TYPE redfish_call_success gauge
+        redfish_call_success 0.0
+
+    would return,
+        {
+          "ipmi_sensors": [
+                            Metric(name='ipmi_temperature_celsius',
+                            labels='name="Exhaust Temp",state="Nominal",unit="C"',
+                            value=52.0), Metric(name='ipmi_power_watts',
+                            labels='name="Sys Fan Pwr",state="Nominal",unit="W"',
+                            value=20.0)
+                          ],
+          "mega_raid":    [
+                            Metric(name='megaraid_virtual_drives',
+                            labels='controller_id="0"',
+                            value=1.0)
+                          ],
+          "redfish":      [Metric(name='redfish_call_success', labels=None, value=0.0)],
+        }
+    """
+    metrics_list: Optional[list[Metric]] = []
+
+    for line in metrics_input.split("\n"):
+        if metric := _parse_single_metric(line):
+            metrics_list.append(metric)
+
+    parsed_metrics = defaultdict(list)
+    for metric in metrics_list:
+        name = metric.name
+        if name.startswith("redfish"):
+            parsed_metrics["redfish"].append(metric)
+        elif name.startswith("ipmi_dcmi"):
+            parsed_metrics["ipmi_dcmi"].append(metric)
+        elif name.startswith("ipmi_sel"):
+            parsed_metrics["ipmi_sel"].append(metric)
+        elif name.startswith("ipmi"):
+            parsed_metrics["ipmi_sensors"].append(metric)
+        elif name.startswith("poweredgeraid"):
+            parsed_metrics["poweredge_raid"].append(metric)
+        elif name.startswith("megaraid") or name.startswith("storcli"):
+            parsed_metrics["mega_raid"].append(metric)
+    return parsed_metrics
 
 
 class AppStatus(str, Enum):
@@ -123,6 +231,52 @@ async def test_build_and_deploy(ops_test: OpsTest, series, sync_helper):
         assert results.get("return-code") == 0
         assert results.get("stdout").strip() == "active"
         assert unit.workload_status_message == AppStatus.READY
+
+
+@pytest.mark.realhw
+class TestCharmWithHW:
+    """Run functional tests that require specific hardware."""
+
+    async def test_config_collector_enabled(
+        self, app, unit, sync_helper, ops_test, provided_collectors
+    ):
+        """Test whether provided collectors are present in exporter config."""
+        cmd = "cat /etc/hardware-exporter-config.yaml"
+        results = await sync_helper.run_command_on_unit(ops_test, unit.name, cmd)
+        assert results.get("return-code") == 0
+        config = yaml.safe_load(results.get("stdout").strip())
+        for collector_name in provided_collectors:
+            assert f"collector.{collector_name}" in config.get("enable_collectors")
+
+    async def test_metrics_available(self, app, unit, sync_helper, ops_test):
+        """Test if metrics are available at the expected endpoint on unit."""
+        results = await sync_helper.get_metrics_output(ops_test, unit.name)
+        assert results.get("return-code") == 0, "Metrics output not available"
+
+    @pytest.mark.parametrize(
+        "collector",
+        [
+            "ipmi_dcmi",
+            "ipmi_sel",
+            "ipmi_sensors",
+            "redfish",
+            "poweredge_raid",
+            "mega_raid",
+            "lsi_sas_2",
+            "lsi_sas_3",
+        ],
+    )
+    async def test_collector_specific_metrics_available(
+        self, ops_test, app, unit, sync_helper, provided_collectors, collector
+    ):
+        """Test if metrics specific to provided collectors are present."""
+        if collector not in provided_collectors:
+            pytest.skip(f"{collector} not in provided collectors, skipping test")
+
+        # collector is available, proceed to run collector specific tests
+        results = await sync_helper.get_metrics_output(ops_test, unit.name)
+        parsed_metrics = parse_metrics(results.get("stdout").strip())
+        assert parsed_metrics.get(collector), f"{collector} specific metrics are not available."
 
 
 class TestCharm:

--- a/tests/functional/test_charm.py
+++ b/tests/functional/test_charm.py
@@ -128,7 +128,7 @@ async def test_build_and_deploy(ops_test: OpsTest, series, sync_helper):
 class TestCharm:
     """Perform basic functional testing of the charm without having the actual hardware."""
 
-    async def test_00_config_changed_port(self, app, unit, sync_helper, ops_test):
+    async def test_config_changed_port(self, app, unit, sync_helper, ops_test):
         """Test changing the config option: exporter-port."""
         new_port = "10001"
         await asyncio.gather(
@@ -144,7 +144,7 @@ class TestCharm:
 
         await app.reset_config(["exporter-port"])
 
-    async def test_01_config_changed_log_level(self, app, unit, sync_helper, ops_test):
+    async def test_config_changed_log_level(self, app, unit, sync_helper, ops_test):
         """Test changing the config option: exporter-log-level."""
         new_log_level = "DEBUG"
         await asyncio.gather(
@@ -160,7 +160,7 @@ class TestCharm:
 
         await app.reset_config(["exporter-log-level"])
 
-    async def test_10_start_and_stop_exporter(self, app, unit, sync_helper, ops_test):
+    async def test_start_and_stop_exporter(self, app, unit, sync_helper, ops_test):
         """Test starting and stopping the exporter results in correct charm status."""
         # Stop the exporter, and the exporter should auto-restart after update status fire.
         stop_cmd = "systemctl stop hardware-exporter"
@@ -171,7 +171,7 @@ class TestCharm:
             )
             assert unit.workload_status_message == AppStatus.READY
 
-    async def test_11_exporter_failed(self, app, unit, sync_helper, ops_test):
+    async def test_exporter_failed(self, app, unit, sync_helper, ops_test):
         """Test failure in the exporter results in correct charm status."""
         # Setting incorrect log level will crash the exporter
         async with ops_test.fast_forward():
@@ -188,7 +188,7 @@ class TestCharm:
             )
             assert unit.workload_status_message == AppStatus.READY
 
-    async def test_20_on_remove_event(self, app, sync_helper, ops_test):
+    async def test_on_remove_event(self, app, sync_helper, ops_test):
         """Test _on_remove event cleans up the service on the host machine."""
         await asyncio.gather(
             app.remove_relation(f"{APP_NAME}:general-info", f"{PRINCIPAL_APP_NAME}:juju-info"),

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -1,0 +1,131 @@
+"""Helper functions to run functional tests for hardware-observer."""
+
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Optional
+
+from async_lru import alru_cache
+
+from config import EXPORTER_DEFAULT_PORT
+
+
+async def run_command_on_unit(ops_test, unit_name, command):
+    complete_command = ["exec", "--unit", unit_name, "--", *command.split()]
+    return_code, stdout, _ = await ops_test.juju(*complete_command)
+    results = {
+        "return-code": return_code,
+        "stdout": stdout,
+    }
+    return results
+
+
+@alru_cache
+async def get_metrics_output(ops_test, unit_name):
+    """Return prometheus metric output from endpoint on unit."""
+    command = f"curl localhost:{EXPORTER_DEFAULT_PORT}"
+    results = await run_command_on_unit(ops_test, unit_name, command)
+    return results
+
+
+@dataclass
+class Metric:
+    """Class for metric data."""
+
+    name: str
+    labels: Optional[str]
+    value: float
+
+
+def _parse_single_metric(metric: str) -> Optional[Metric]:
+    """Return a Metric object parsed from a single metric string."""
+    # ignore blank lines or comments
+    if not metric or metric.startswith("#"):
+        return None
+
+    # The regex pattern below uses named capturing groups to extract aspects of the metric.
+    # (?P<name>[^\s{]+) captures the metric name and matches one or more chars that are not
+    # whitespace or opening curly brace '{'
+
+    # (?:{(?P<label>[^}]*)})? handles optional labels It uses a non-capturing group (?:...)
+    # to make the entire portion optional. Inside this group:
+    #   {               : Matches an opening curly brace.
+    #   (?P<label>[^}]*): Another named capturing group (label) that matches zero or more
+    #                     characters that are not a closing curly brace ([^}]*).
+    #   }               : Matches a closing curly brace.
+
+    # (?P<value>\d+\.\d+|\d+): This part captures the numeric value.
+    # It uses a named capturing group (value) and matches either:
+    #   \d+\.\d+  : For obtaining floating point values containing a dot.
+    #   |\d+      : OR, one or more digits for integer values.
+
+    pattern = re.compile(r"(?P<name>[^\s{]+)(?:\{(?P<labels>[^}]*)\})?\s+(?P<value>\d+\.\d+|\d+)")
+    match = pattern.match(metric)
+
+    if match:
+        name = match.group("name")
+        labels = match.group("labels") or None
+        value = float(match.group("value"))
+        return Metric(name=name, labels=labels, value=value)
+    else:
+        return None
+
+
+def parse_metrics(metrics_input: str) -> dict[str, list[Metric]]:
+    """Parse raw metrics and return dictionary of parsed Metric objects for each collector.
+
+    For example, parsing this metrics_input,
+        # HELP ipmi_temperature_celsius Temperature measure from temperature sensors
+        # TYPE ipmi_temperature_celsius gauge
+        ipmi_temperature_celsius{name="Exhaust Temp",state="Nominal",unit="C"} 52.0
+
+        # HELP ipmi_power_watts Power measure from power sensors
+        # TYPE ipmi_power_watts gauge
+        ipmi_power_watts{name="Sys Fan Pwr",state="Nominal",unit="W"} 20.0
+
+        # HELP megaraid_virtual_drives Number of virtual drives
+        # TYPE megaraid_virtual_drives gauge
+        megaraid_virtual_drives{controller_id="0"} 1.0
+
+        # HELP redfish_call_success Indicates if call to the redfish API succeeded or not.
+        # TYPE redfish_call_success gauge
+        redfish_call_success 0.0
+
+    would return,
+        {
+          "ipmi_sensors": [
+                            Metric(name='ipmi_temperature_celsius',
+                            labels='name="Exhaust Temp",state="Nominal",unit="C"',
+                            value=52.0), Metric(name='ipmi_power_watts',
+                            labels='name="Sys Fan Pwr",state="Nominal",unit="W"',
+                            value=20.0)
+                          ],
+          "mega_raid":    [
+                            Metric(name='megaraid_virtual_drives',
+                            labels='controller_id="0"',
+                            value=1.0)
+                          ],
+          "redfish":      [Metric(name='redfish_call_success', labels=None, value=0.0)],
+        }
+    """
+    parsed_metrics = defaultdict(list)
+
+    for line in metrics_input.split("\n"):
+        metric = _parse_single_metric(line)
+        if not metric:
+            continue
+
+        name = metric.name
+        if name.startswith("redfish"):
+            parsed_metrics["redfish"].append(metric)
+        elif name.startswith("ipmi_dcmi"):
+            parsed_metrics["ipmi_dcmi"].append(metric)
+        elif name.startswith("ipmi_sel"):
+            parsed_metrics["ipmi_sel"].append(metric)
+        elif name.startswith("ipmi"):
+            parsed_metrics["ipmi_sensors"].append(metric)
+        elif name.startswith("poweredgeraid"):
+            parsed_metrics["poweredge_raid"].append(metric)
+        elif name.startswith("megaraid") or name.startswith("storcli"):
+            parsed_metrics["mega_raid"].append(metric)
+    return parsed_metrics


### PR DESCRIPTION
This PR is part of the effort to automate many of the manual tests for hardware observer. These tests depend on the availability of actual hardware resources. The tests are not meant to be run as part of CI but provide an easier way to validate functionality with real hardware whenever required, for example, before a new release.

The tests include:
* Check if provided collector is present in the exporter config file
* Verify if metrics are present at the expected endpoint on the unit
* Verify if collector specific metrics (as per the collectors being provided for the tests) are available in the metrics output

Collectors that need to be tested (as per availability on the underlying hardware) can be provided via the `--collectors` flag as space separated arguments. Eg: `--collectors ipmi_sel redfish mega_raid`. These collectors need to belong to a pre-configured list present in `conftest.py`.

The `realhw` marker has also been added to mark the tests which are hardware dependent. If the `--collectors` flag is not provided, then all these tests will be skipped so that only the regular, hardware independent tests are executed.

A `Metric` dataclass has been created to hold the metric data to facilitate testing. The accompanying parsing functions help to convert the raw string of metrics into this structure. Currently, `test_collector_specific_metrics_available` utilizes this to check whether the metrics for the provided collectors are present in the metrics output. In future, this can be used to test for specific value and labels for the metrics.
 
A new `utils.py` module has been added to collect all the helper functions (including the ones from the `SyncHelper` class which have been moved here).

Currently, running these hardware dependent tests require adding the machine to the model beforehand and performing the deployments manually for `hardware-observer`, `grafana-agent` and `ubuntu` applications. The modifications to the `test_build_and_deploy` function for automating this via the bundle and adding the required juju resources will be handled in another PR.