### PR TITLE
Improve dataflow when rendering config file.

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -247,20 +247,20 @@ class HardwareObserverCharm(ops.CharmBase):
             logger.info("Stop and disable exporter service")
         self._on_update_status(event)
 
-    def _get_redfish_creds(self) -> Dict[str, str]:
-        """Provide redfish config if redfish is available, else empty dict."""
+    def _get_redfish_creds(self) -> Dict[str, Any]:
+        """Provide redfish config if redfish is available."""
         bmc_tools = bmc_hw_verifier()
-        if HWTool.REDFISH in bmc_tools:
-            bmc_address = get_bmc_address()
-            redfish_creds = {
-                # Force to use https as default protocol
-                "host": f"https://{bmc_address}",
-                "username": self.model.config.get("redfish-username", ""),
-                "password": self.model.config.get("redfish-password", ""),
-            }
-        else:
-            redfish_creds = {}
-        return redfish_creds
+        if HWTool.REDFISH not in bmc_tools:
+            logger.warning(
+                "Redfish is not available, disregarding redfish credentials config options..."
+            )
+            return {"enable": False}
+        return {
+            "enable": True,
+            "host": f"https://{get_bmc_address()}",
+            "username": self.model.config.get("redfish-username", ""),
+            "password": self.model.config.get("redfish-password", ""),
+        }
 
     def validate_exporter_configs(self) -> Tuple[bool, str]:
         """Validate the static and runtime config options for the exporter."""

--- a/src/service.py
+++ b/src/service.py
@@ -15,7 +15,6 @@ from config import (
     EXPORTER_NAME,
     EXPORTER_SERVICE_PATH,
     EXPORTER_SERVICE_TEMPLATE,
-    HWTool,
 )
 from hw_tools import get_hw_tool_white_list
 
@@ -91,7 +90,7 @@ class ExporterTemplate:
             PORT=port,
             LEVEL=level,
             COLLECTORS=collectors,
-            REDFISH_ENABLE=(HWTool.REDFISH in hw_tools),
+            REDFISH_ENABLE=redfish_creds.get("enable", False),
             REDFISH_HOST=redfish_creds.get("host", ""),
             REDFISH_USERNAME=redfish_creds.get("username", ""),
             REDFISH_PASSWORD=redfish_creds.get("password", ""),

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -121,7 +121,7 @@ class TestCharm(unittest.TestCase):
         self.assertTrue(self.harness.charm._stored.resource_installed)
 
         self.harness.charm.exporter.install.assert_called_with(
-            int(EXPORTER_DEFAULT_PORT), "INFO", {}
+            int(EXPORTER_DEFAULT_PORT), "INFO", {"enable": False}
         )
 
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())

--- a/tests/unit/test_exporter.py
+++ b/tests/unit/test_exporter.py
@@ -327,7 +327,7 @@ class TestExporterTemplate(unittest.TestCase):
             self.template.render_config(
                 port="80",
                 level="info",
-                redfish_creds={},
+                redfish_creds={"enable": False},
             )
             mock_install.assert_called_with(
                 EXPORTER_CONFIG_PATH,
@@ -349,6 +349,7 @@ class TestExporterTemplate(unittest.TestCase):
                 port="80",
                 level="info",
                 redfish_creds={
+                    "enable": True,
                     "host": "127.0.0.1",
                     "username": "default_user",
                     "password": "default_pwd",


### PR DESCRIPTION
Currently, `service.ExporterTemplate.render_config` determine `REDFISH_ENABLE` (jinja2) variable by  `get_hw_tool_white_list`, but the same information is also retrieved in `charm.HardwareObserverCharm._get_redfish_creds` via `bmc_hw_verifier`. If the two does not match (e.g. `bmc_hw_verifier` determines it redfish is not available but `get_hw_tool_white_list` determines that redfish is available), it will cause issue mentioned in #130.

This PR tries to remove the possibility that the two information is inconsistent by relying on single source of truth. Note, it might not solve #130, since the root cause is not clear, and it's not reproducible from my environement.