### PR TITLE
Remove config validation in update status hook

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -127,11 +127,6 @@ class HardwareObserverCharm(ops.CharmBase):
             self.model.unit.status = BlockedStatus("Cannot relate to more than one grafana-agent")
             return
 
-        config_valied, confg_valid_message = self.validate_exporter_configs()
-        if not config_valied:
-            self.model.unit.status = BlockedStatus(confg_valid_message)
-            return
-
         hw_tool_ok, error_msg = self.hw_tool_helper.check_installed()
         if not hw_tool_ok:
             self.model.unit.status = BlockedStatus(error_msg)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -251,8 +251,8 @@ class TestCharm(unittest.TestCase):
 
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
-    def test_13_update_status_config_invalid(self, mock_hw_tool_helper, mock_exporter):
-        """Test update_status when everything is okay."""
+    def test_13_config_changed_config_invalid(self, mock_hw_tool_helper, mock_exporter):
+        """Test config changed hook when config is invalid."""
         self.mock_bmc_hw_verifier.return_value = [
             HWTool.IPMI_SENSOR,
             HWTool.IPMI_SEL,
@@ -269,7 +269,7 @@ class TestCharm(unittest.TestCase):
         self.harness.charm.validate_exporter_configs = mock.MagicMock()
         self.harness.charm.validate_exporter_configs.return_value = (False, "config fail message")
 
-        self.harness.charm.on.update_status.emit()
+        self.harness.charm.on.config_changed.emit()
         self.assertEqual(self.harness.charm.unit.status, BlockedStatus("config fail message"))
 
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())


### PR DESCRIPTION
The config validation does not make sense in update status hook because the config options will not change on update status, and the same validation is already done in config changed hook.