### PR TITLE
fix: Remove redfish credential validation in install event handler

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -143,11 +143,14 @@ class HardwareObserverCharm(ops.CharmBase):
             self.model.unit.status = BlockedStatus(error_msg)
             return
 
-        if self._stored.exporter_installed:  # type: ignore[truthy-function]
-            if not self.exporter.check_active():
-                logger.warning("Exporter health check - failed.")
-                # if restart isn't successful, an ExporterError exception will be raised here
-                self.restart_exporter()
+        if not self._stored.exporter_installed:  # type: ignore[truthy-function]
+            logger.warning("Exporter not installed")  # type: ignore[unreachable]
+            return
+
+        if not self.exporter.check_health():
+            logger.warning("Exporter health check - failed.")
+            # if restart isn't successful, an ExporterError exception will be raised here
+            self.restart_exporter()
 
         self.model.unit.status = ActiveStatus("Unit is ready")
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -125,6 +125,10 @@ class HardwareObserverCharm(ops.CharmBase):
             # The charm should be in BlockedStatus with install failed msg
             return  # type: ignore[unreachable]
 
+        if not self._stored.exporter_installed:  # type: ignore[truthy-function]
+            # The charm should be in BlockedStatus with exporter install failed msg
+            return  # type: ignore[unreachable]
+
         config_valid, config_valid_message = self.validate_exporter_configs()
         if not config_valid:
             self.model.unit.status = BlockedStatus(config_valid_message)
@@ -141,10 +145,6 @@ class HardwareObserverCharm(ops.CharmBase):
         hw_tool_ok, error_msg = self.hw_tool_helper.check_installed()
         if not hw_tool_ok:
             self.model.unit.status = BlockedStatus(error_msg)
-            return
-
-        if not self._stored.exporter_installed:  # type: ignore[truthy-function]
-            logger.warning("Exporter not installed")  # type: ignore[unreachable]
             return
 
         if not self.exporter.check_health():

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -221,6 +221,7 @@ class TestCharm(unittest.TestCase):
         """Test config change event updates the charm's internal store."""
         self.harness.begin()
         self.harness.charm._stored.resource_installed = True
+        self.harness.charm._stored.exporter_installed = True
 
         new_config = {"exporter-port": 80, "exporter-log-level": "DEBUG"}
         self.harness.update_config(new_config)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -206,6 +206,13 @@ class TestCharm(unittest.TestCase):
         self.harness.add_relation("cos-agent", "grafana-agent")
         self.harness.begin()
         self.harness.charm._stored.resource_installed = True
+        self.harness.charm._stored.exporter_installed = False
+
+        # no exception should be raised
+        self.harness.charm.on.update_status.emit()
+
+        # exception raised, exporter should crash
+        self.harness.charm._stored.exporter_installed = True
         with self.assertRaises(ExporterError):
             self.harness.charm.on.update_status.emit()
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -59,16 +59,16 @@ class TestCharm(unittest.TestCase):
                 notice_count += 1
         return notice_count
 
-    def test_01_harness(self) -> None:
-        """Test charm initialise."""
+    def test_harness(self) -> None:
+        """Test charm initialize."""
         self.harness.begin()
         self.assertFalse(self.harness.charm._stored.resource_installed)
         self.assertTrue(isinstance(self.harness.charm._stored.config, ops.framework.StoredDict))
 
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
-    def test_02_install(self, mock_hw_tool_helper, mock_exporter) -> None:
-        """Test event install."""
+    def test_install(self, mock_hw_tool_helper, mock_exporter) -> None:
+        """Test install event handler."""
         mock_hw_tool_helper.return_value.install.return_value = (True, "")
         mock_exporter.return_value.install.return_value = True
         self.harness.begin()
@@ -83,8 +83,8 @@ class TestCharm(unittest.TestCase):
 
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
-    def test_03_upgrade_charm(self, mock_hw_tool_helper, mock_exporter) -> None:
-        """Test event upgrade_charm."""
+    def test_upgrade_charm(self, mock_hw_tool_helper, mock_exporter) -> None:
+        """Test upgrade_charm event handler."""
         mock_hw_tool_helper.return_value.install.return_value = (True, "")
         mock_exporter.return_value.install.return_value = True
         self.harness.begin()
@@ -101,8 +101,8 @@ class TestCharm(unittest.TestCase):
 
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
-    def test_04_install_missing_resources(self, mock_hw_tool_helper, mock_exporter) -> None:
-        """Test event install."""
+    def test_install_missing_resources(self, mock_hw_tool_helper, mock_exporter) -> None:
+        """Test install event handler when resources are missing."""
         mock_hw_tool_helper.return_value.install.return_value = (
             False,
             "Missing resources: ['storcli-deb']",
@@ -116,8 +116,8 @@ class TestCharm(unittest.TestCase):
 
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
-    def test_05_install_redfish_unavailable(self, mock_hw_tool_helper, mock_exporter) -> None:
-        """Test event install."""
+    def test_install_redfish_unavailable(self, mock_hw_tool_helper, mock_exporter) -> None:
+        """Test install event handler when redfish is unavailable."""
         self.mock_bmc_hw_verifier.return_value = [
             HWTool.IPMI_SENSOR,
             HWTool.IPMI_SEL,
@@ -138,8 +138,8 @@ class TestCharm(unittest.TestCase):
 
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
-    def test_06_install_failed(self, mock_hw_tool_helper, mock_exporter) -> None:
-        """Test event install."""
+    def test_exporter_install_fail(self, mock_hw_tool_helper, mock_exporter) -> None:
+        """Test exporter install failure."""
         mock_hw_tool_helper.return_value.install.return_value = (True, "")
         mock_exporter.return_value.install.return_value = False
         self.harness.begin()
@@ -153,8 +153,8 @@ class TestCharm(unittest.TestCase):
 
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
-    def test_07_update_status_all_green(self, mock_hw_tool_helper, mock_exporter):
-        """Test update_status when everything is okay."""
+    def test_update_status_all_green(self, mock_hw_tool_helper, mock_exporter):
+        """Test update_status event handler when everything is okay."""
         self.mock_bmc_hw_verifier.return_value = [
             HWTool.IPMI_SENSOR,
             HWTool.IPMI_SEL,
@@ -173,8 +173,8 @@ class TestCharm(unittest.TestCase):
 
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
-    def test_08_update_status_check_installed_false(self, mock_hw_tool_helper, mock_exporter):
-        """Test update_status when hw tool checks failed."""
+    def test_update_status_check_installed_false(self, mock_hw_tool_helper, mock_exporter):
+        """Test update_status event handler when hw tool checks failed."""
         self.mock_bmc_hw_verifier.return_value = [
             HWTool.IPMI_SENSOR,
             HWTool.IPMI_SEL,
@@ -193,7 +193,7 @@ class TestCharm(unittest.TestCase):
 
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
-    def test_09_update_status_exporter_crashed(self, mock_hw_tool_helper, mock_exporter):
+    def test_update_status_exporter_crashed(self, mock_hw_tool_helper, mock_exporter):
         """Test update_status."""
         self.mock_bmc_hw_verifier.return_value = [
             HWTool.IPMI_SENSOR,
@@ -217,7 +217,7 @@ class TestCharm(unittest.TestCase):
             self.harness.charm.on.update_status.emit()
 
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())
-    def test_10_config_changed(self, mock_exporter):
+    def test_config_changed(self, mock_exporter):
         """Test config change event updates the charm's internal store."""
         self.harness.begin()
         self.harness.charm._stored.resource_installed = True
@@ -235,8 +235,8 @@ class TestCharm(unittest.TestCase):
         )
 
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())
-    def test_11_config_changed_before_install_complete(self, mock_exporter):
-        """Test: config change event is deferred if charm not installed."""
+    def test_config_changed_before_install_complete(self, mock_exporter):
+        """Test config change event is deferred if charm not installed."""
         self.harness.begin()
         self.harness.charm._stored.resource_installed = False
 
@@ -245,8 +245,8 @@ class TestCharm(unittest.TestCase):
 
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
-    def test_12_upgrade_force_reconfig_exporter(self, mock_hw_tool_helper, mock_exporter) -> None:
-        """Test event install."""
+    def test_upgrade_force_reconfig_exporter(self, mock_hw_tool_helper, mock_exporter) -> None:
+        """Test upgrade event handler will reconfigure exporter."""
         mock_hw_tool_helper.return_value.install.return_value = (True, "")
         mock_exporter.return_value.install.return_value = True
         self.harness.begin()
@@ -264,8 +264,8 @@ class TestCharm(unittest.TestCase):
 
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
-    def test_13_update_status_config_invalid(self, mock_hw_tool_helper, mock_exporter):
-        """Test update_status when everything is okay."""
+    def test_update_status_config_invalid(self, mock_hw_tool_helper, mock_exporter):
+        """Test update_status event handler when config is invalid."""
         self.mock_bmc_hw_verifier.return_value = [
             HWTool.IPMI_SENSOR,
             HWTool.IPMI_SEL,
@@ -287,7 +287,7 @@ class TestCharm(unittest.TestCase):
 
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
-    def test_14_config_changed_update_alert_rules(self, mock_hw_tool_helper, mock_exporter):
+    def test_config_changed_update_alert_rules(self, mock_hw_tool_helper, mock_exporter):
         """Test config changed will update alert rule."""
         self.mock_bmc_hw_verifier.return_value = [
             HWTool.IPMI_SENSOR,
@@ -323,8 +323,8 @@ class TestCharm(unittest.TestCase):
 
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
-    def test_15_upgrade_charm_update_alert_rules(self, mock_hw_tool_helper, mock_exporter):
-        """Test upgrade charm will update alert rule."""
+    def test_upgrade_charm_update_alert_rules(self, mock_hw_tool_helper, mock_exporter):
+        """Test upgrade charm event updates alert rule."""
         self.mock_bmc_hw_verifier.return_value = [
             HWTool.IPMI_SENSOR,
             HWTool.IPMI_SEL,
@@ -359,10 +359,10 @@ class TestCharm(unittest.TestCase):
 
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
-    def test_16_install_redfish_enabled_with_correct_credential(
+    def test_install_redfish_enabled_with_correct_credential(
         self, mock_hw_tool_helper, mock_exporter
     ) -> None:
-        """Test event install when redfish is available and credential is correct."""
+        """Test install event when redfish is available and credential is correct."""
         self.mock_bmc_hw_verifier.return_value = [
             HWTool.REDFISH,
         ]
@@ -381,7 +381,7 @@ class TestCharm(unittest.TestCase):
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
     @mock.patch("charm.redfish_client", return_value=mock.MagicMock())
-    def test_17_install_redfish_enabled_with_incorrect_credential(
+    def test_install_redfish_enabled_with_incorrect_credential(
         self, test_exception, mock_redfish_client, mock_hw_tool_helper, mock_exporter
     ) -> None:
         """Test event install when redfish is available but credential is wrong."""
@@ -405,7 +405,7 @@ class TestCharm(unittest.TestCase):
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
     @mock.patch("charm.redfish_client", return_value=mock.MagicMock())
-    def test_18_config_changed_redfish_enabled_with_incorrect_credential(
+    def test_config_changed_redfish_enabled_with_incorrect_credential(
         self, test_exception, mock_redfish_client, mock_hw_tool_helper, mock_exporter
     ) -> None:
         """Test event config changed when redfish is available but credential is wrong."""


### PR DESCRIPTION
Fixes #190 

The `exporter.check_active` method being called in the `restart_exporter` method (from the update status event handler) will fail in case the exporter installation has not been done. This installation process takes place as part of the install event handler. 

The error happens because the `check_installed` function in `service.py` (called as a decorator for the various exporter service helper methods) would return `False` when the exporter isn't installed. This would cause all the Exporter class' methods in service.py (restart, check_active, check_health etc.) to return `False`. The issue occurs when the  `on_update_status()` --> `restart_exporter()` raises an exception when `exporter.check_active` consistently returns `False`. 

This PR removes the redfish credential validation step during the install event since it's likely to not have the right configuration during the installation. Moreover, this can leave the charm in an inconsistent state where the exporter is not properly installed, leading to an error during the execution of other lifecycle events.