### PR TITLE
chore: Remove pin on ops version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,6 @@
 cosl
 distro
-# ops v2.10.0 breaks unit tests with the following error
-# ops.model.ModelError: ERROR invalid status "error", expected one of [maintenance blocked waiting active]
-# caused due to this change: https://github.com/canonical/operator/pull/1107
-ops >= 2.2.0, <2.10.0
+ops >= 2.2.0
 jinja2
 redfish  # requests is included in this
 git+https://github.com/canonical/prometheus-hardware-exporter.git


### PR DESCRIPTION
With https://github.com/canonical/hardware-observer-operator/pull/191, we are now not raising `ErrorStatus` directly and the unit tests have also been changed to reflect this.

This means that we can use the latest version of ops again.

Reverts change from [this commit](https://github.com/canonical/hardware-observer-operator/commit/a3002ee790d02bc9425dd18b1c6422f70d66693b).