### PR TITLE
tests: Add hw dependent tests for redfish cred validation

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -58,9 +58,11 @@ def pytest_collection_modifyitems(config, items):
         )
         for item in items:
             # skip TestCharm tests where "realhw" marker is not present
-            # we don't want to skip test_setup_and_build even for hw independent tests
-            # so we also check for the skip_if_deployed marker
-            if "realhw" not in item.keywords and "skip_if_deployed" not in item.keywords:
+            # we don't want to skip test_setup_and_build, test_required_resources,
+            # test_cos_agent_relation and test_redfish_credential_validation
+            # even for hw independent tests
+            # so we also check for the abort_on_fail marker
+            if "realhw" not in item.keywords and "abort_on_fail" not in item.keywords:
                 item.add_marker(skip_hw_independent)
     else:
         # skip hw dependent tests in TestCharmWithHW marked with "realhw"


### PR DESCRIPTION
Adds `test_redfish_credential_validation` which sets the redfish credentials and checks if the charm is funtioning as intended. This is necessary for hardware dependent tests since the charm only goes to active state once the correct redfish credentials are configured (assuming redfish is present on the underlying machine).  

`test_build_and_deploy` is broken up into smaller tests so that they are easier to manage. Also modifies logic in conftest.py so that all these tests are executed whether they're hw dependent or independent.

`test_redfish_metrics` has also been modified since we are setting the redfish credentials as part of the earlier test. The resource based tests (`test_resource_in_correct_location`, `test_wrong_resource_attached` and `test_resource_clean_up`) have been moved towards the end of `TestCharmWithHW` so that all the metrics based tests can be grouped together in the beginning.

Finally, a retry mechanism has been added to `test_metrics_available` as it was found while testing that it takes some time for the endpoint to be ready with the metrics.

Note: Requires #192 to be merged.