### PR TITLE
Retry alerts to be fired for longer duration

### DIFF
--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -32,9 +32,9 @@ class Alert:
     value: float
     labels: dict
 
-    def __eq__(self, other) -> bool:
-        """Implement equals based only on relevant fields."""
-        if self.value != other.value:
+    def is_same_alert(self, other) -> bool:
+        """Check if the two alerts are the same based on relevant fields."""
+        if self.state != other.state or self.value != other.value:
             return False
         for key, value in self.labels.items():
             if other.labels.get(key) != value:

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -34,7 +34,7 @@ class Alert:
 
     def __eq__(self, other) -> bool:
         """Implement equals based only on relevant fields."""
-        if self.state != other.state or self.value != other.value:
+        if self.value != other.value:
             return False
         for key, value in self.labels.items():
             if other.labels.get(key) != value:


### PR DESCRIPTION
#199 , increases the duration of ipmi alerts, which caused the tests to fail because the alerts are in `Pending` state and not `Firing` for 5 minutes.  
This increases the retry time to 15 minutes, so that gives enough time for those alerts to be in `Firing` state.