### PR TITLE
Recreate sdr cache if it's out of date or invalid

### DIFF
--- a/src/hw_tools.py
+++ b/src/hw_tools.py
@@ -475,13 +475,13 @@ def bmc_hw_verifier() -> List[HWTool]:
     apt_helpers.add_pkg_with_candidate_version("freeipmi-tools")
 
     try:
-        subprocess.check_output("ipmimonitoring".split())
+        subprocess.check_output("ipmimonitoring --sdr-cache-recreate".split())
         tools.append(HWTool.IPMI_SENSOR)
     except subprocess.CalledProcessError:
         logger.info("IPMI sensors monitoring is not available")
 
     try:
-        subprocess.check_output("ipmi-sel".split())
+        subprocess.check_output("ipmi-sel --sdr-cache-recreate".split())
         tools.append(HWTool.IPMI_SEL)
     except subprocess.CalledProcessError:
         logger.info("IPMI SEL monitoring is not available")

--- a/tests/unit/test_hw_tools.py
+++ b/tests/unit/test_hw_tools.py
@@ -936,9 +936,9 @@ class TestIPMIHWVerifier(unittest.TestCase):
         """Test a mixture of failures and successes for ipmi."""
 
         def mock_get_response_ipmi(ipmi_call):
-            if ipmi_call == "ipmimonitoring".split():
+            if ipmi_call == "ipmimonitoring --sdr-cache-recreate".split():
                 pass
-            elif ipmi_call == "ipmi-sel".split():
+            elif ipmi_call == "ipmi-sel --sdr-cache-recreate".split():
                 pass
             elif ipmi_call == "ipmi-dcmi --get-system-power-statistics".split():
                 raise subprocess.CalledProcessError(-1, "cmd")


### PR DESCRIPTION
Recreate the SDR cache if it's out of date, and hence the `ipmi-sel` and `ipmi-sensor` collectors won't be disabled, just because SDR cache was out of date. 