### PR TITLE
Store hw tool list in _stored and reuse it.

### DIFF
--- a/src/hw_tools.py
+++ b/src/hw_tools.py
@@ -569,9 +569,9 @@ class HWToolHelper:
             return False, f"Missing resources: {missing_resources}"
         return True, ""
 
-    def install(self, resources: Resources) -> Tuple[bool, str]:
+    def install(self, resources: Resources, enable_hw_tool_list: List[HWTool]) -> Tuple[bool, str]:
         """Install tools."""
-        hw_white_list: List[HWTool] = get_hw_tool_white_list()
+        hw_white_list: List[HWTool] = enable_hw_tool_list
         logger.info("hw_white_list: %s", hw_white_list)
 
         fetch_tools: Dict[HWTool, Path] = self.fetch_tools(resources, hw_white_list)
@@ -609,9 +609,10 @@ class HWToolHelper:
             return False, f"Fail strategies: {fail_strategies}"
         return True, ""
 
-    def remove(self, resources: Resources) -> None:  # pylint: disable=W0613
+    # pylint: disable=W0613
+    def remove(self, resources: Resources, enable_hw_tool_list: List[HWTool]) -> None:
         """Execute all remove strategies."""
-        hw_white_list: List[HWTool] = get_hw_tool_white_list()
+        hw_white_list: List[HWTool] = enable_hw_tool_list
         for strategy in self.strategies:
             if strategy.name not in hw_white_list:
                 continue
@@ -619,9 +620,9 @@ class HWToolHelper:
                 strategy.remove()
             logger.info("Strategy %s remove success", strategy)
 
-    def check_installed(self) -> Tuple[bool, str]:
+    def check_installed(self, enable_hw_tool_list: List[HWTool]) -> Tuple[bool, str]:
         """Check tool status."""
-        hw_white_list: List[HWTool] = get_hw_tool_white_list()
+        hw_white_list: List[HWTool] = enable_hw_tool_list
         failed_checks: List[HWTool] = []
 
         for strategy in self.strategies:

--- a/src/service.py
+++ b/src/service.py
@@ -3,7 +3,7 @@
 from functools import wraps
 from logging import getLogger
 from pathlib import Path
-from typing import Any, Callable, Dict, Tuple
+from typing import Any, Callable, Dict, List, Tuple, Union
 
 from charms.operator_libs_linux.v1 import systemd
 from jinja2 import Environment, FileSystemLoader
@@ -15,6 +15,7 @@ from config import (
     EXPORTER_NAME,
     EXPORTER_SERVICE_PATH,
     EXPORTER_SERVICE_TEMPLATE,
+    HWTool,
 )
 from hw_tools import get_hw_tool_white_list
 
@@ -85,11 +86,20 @@ class ExporterTemplate:
             logger.info("Removing file '%s' - Done.", path)
         return success
 
+    # pylint: disable=too-many-arguments
     def render_config(
-        self, port: int, level: str, collect_timeout: int, redfish_conn_params: dict
+        self,
+        port: int,
+        level: str,
+        collect_timeout: int,
+        redfish_conn_params: dict,
+        enable_hw_tool_list: Union[List[HWTool], None] = None,
     ) -> bool:
         """Render and install exporter config file."""
-        hw_tools = get_hw_tool_white_list()
+        if enable_hw_tool_list is not None:
+            hw_tools = enable_hw_tool_list
+        else:
+            hw_tools = get_hw_tool_white_list()
         collectors = []
         for tool in hw_tools:
             collector = EXPORTER_COLLECTOR_MAPPING.get(tool)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -28,15 +28,15 @@ class TestCharm(unittest.TestCase):
         self.mock_get_bmc_address.return_value = "127.0.0.1"
         self.addCleanup(get_bmc_address_patcher.stop)
 
-        bmc_hw_verifier_patcher = mock.patch.object(charm, "bmc_hw_verifier")
-        self.mock_bmc_hw_verifier = bmc_hw_verifier_patcher.start()
-        self.mock_bmc_hw_verifier.return_value = [
+        get_hw_tool_white_list_patcher = mock.patch.object(charm, "get_hw_tool_white_list")
+        self.mock_get_hw_tool_white_list = get_hw_tool_white_list_patcher.start()
+        self.mock_get_hw_tool_white_list.return_value = [
             HWTool.IPMI_SENSOR,
             HWTool.IPMI_SEL,
             HWTool.IPMI_DCMI,
             HWTool.REDFISH,
         ]
-        self.addCleanup(bmc_hw_verifier_patcher.stop)
+        self.addCleanup(get_hw_tool_white_list_patcher.stop)
 
         redfish_client_patcher = mock.patch("charm.redfish_client")
         redfish_client_patcher.start()
@@ -71,13 +71,15 @@ class TestCharm(unittest.TestCase):
         mock_hw_tool_helper.return_value.install.return_value = (True, "")
         mock_exporter.return_value.install.return_value = True
         self.harness.begin()
+        self.harness.charm._stored.enable_hw_tool_list_values = []
         self.harness.charm.on.install.emit()
 
         self.assertTrue(self.harness.charm._stored.resource_installed)
 
         self.harness.charm.exporter.install.assert_called_once()
         self.harness.charm.hw_tool_helper.install.assert_called_with(
-            self.harness.charm.model.resources
+            self.harness.charm.model.resources,
+            self.harness.charm._stored.enable_hw_tool_list_values,
         )
 
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())
@@ -87,13 +89,15 @@ class TestCharm(unittest.TestCase):
         mock_hw_tool_helper.return_value.install.return_value = (True, "")
         mock_exporter.return_value.install.return_value = True
         self.harness.begin()
+        self.harness.charm._stored.enable_hw_tool_list_values = []
         self.harness.charm.on.install.emit()
 
         self.assertTrue(self.harness.charm._stored.resource_installed)
 
         self.harness.charm.exporter.install.assert_called_once()
         self.harness.charm.hw_tool_helper.install.assert_called_with(
-            self.harness.charm.model.resources
+            self.harness.charm.model.resources,
+            self.harness.charm._stored.enable_hw_tool_list_values,
         )
 
         self.harness.charm.unit.status = ActiveStatus("Install complete")
@@ -117,7 +121,7 @@ class TestCharm(unittest.TestCase):
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
     def test_install_redfish_unavailable(self, mock_hw_tool_helper, mock_exporter) -> None:
         """Test install event handler when redfish is unavailable."""
-        self.mock_bmc_hw_verifier.return_value = [
+        self.mock_get_hw_tool_white_list.return_value = [
             HWTool.IPMI_SENSOR,
             HWTool.IPMI_SEL,
             HWTool.IPMI_DCMI,
@@ -158,7 +162,7 @@ class TestCharm(unittest.TestCase):
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
     def test_update_status_all_green(self, mock_hw_tool_helper, mock_exporter):
         """Test update_status event handler when everything is okay."""
-        self.mock_bmc_hw_verifier.return_value = [
+        self.mock_get_hw_tool_white_list.return_value = [
             HWTool.IPMI_SENSOR,
             HWTool.IPMI_SEL,
             HWTool.IPMI_DCMI,
@@ -178,7 +182,7 @@ class TestCharm(unittest.TestCase):
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
     def test_update_status_check_installed_false(self, mock_hw_tool_helper, mock_exporter):
         """Test update_status event handler when hw tool checks failed."""
-        self.mock_bmc_hw_verifier.return_value = [
+        self.mock_get_hw_tool_white_list.return_value = [
             HWTool.IPMI_SENSOR,
             HWTool.IPMI_SEL,
             HWTool.IPMI_DCMI,
@@ -198,7 +202,7 @@ class TestCharm(unittest.TestCase):
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
     def test_update_status_exporter_crashed(self, mock_hw_tool_helper, mock_exporter):
         """Test update_status."""
-        self.mock_bmc_hw_verifier.return_value = [
+        self.mock_get_hw_tool_white_list.return_value = [
             HWTool.IPMI_SENSOR,
             HWTool.IPMI_SEL,
             HWTool.IPMI_DCMI,
@@ -212,10 +216,9 @@ class TestCharm(unittest.TestCase):
         with self.assertRaises(ExporterError):
             self.harness.charm.on.update_status.emit()
 
-    @mock.patch.object(charm, "bmc_hw_verifier", return_value=[])
     @mock.patch("charm.HWToolHelper")
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())
-    def test_config_changed(self, mock_exporter, mock_hw_tool_helper, mock_bmc_hw_verifier):
+    def test_config_changed(self, mock_exporter, mock_hw_tool_helper):
         """Test config change event renders config file."""
         self.harness.begin()
         self.harness.charm._stored.resource_installed = True
@@ -233,12 +236,9 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(self.harness.charm.unit.status, ActiveStatus("Unit is ready"))
 
-    @mock.patch.object(charm, "bmc_hw_verifier", return_value=[])
     @mock.patch("charm.HWToolHelper")
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())
-    def test_config_changed_without_cos_agent_relation(
-        self, mock_exporter, mock_hw_tool_helper, mock_bmc_hw_verifier
-    ):
+    def test_config_changed_without_cos_agent_relation(self, mock_exporter, mock_hw_tool_helper):
         """Test config change event don't render config file if cos_agent relation is missing."""
         self.harness.begin()
         self.harness.charm._stored.resource_installed = True
@@ -275,7 +275,7 @@ class TestCharm(unittest.TestCase):
         mock_exporter.return_value.install.return_value = True
         self.harness.begin()
         self.harness.charm._stored.exporter_installed = True
-        print(dir(self.harness.charm.on))
+        self.harness.charm._stored.enable_hw_tool_list_values = []
         self.harness.charm.on.upgrade_charm.emit()
 
         self.assertTrue(self.harness.charm._stored.resource_installed)
@@ -283,14 +283,15 @@ class TestCharm(unittest.TestCase):
 
         self.harness.charm.exporter.install.assert_called_once()
         self.harness.charm.hw_tool_helper.install.assert_called_with(
-            self.harness.charm.model.resources
+            self.harness.charm.model.resources,
+            self.harness.charm._stored.enable_hw_tool_list_values,
         )
 
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
     def test_update_status_config_invalid(self, mock_hw_tool_helper, mock_exporter):
         """Test update_status event handler when config is invalid."""
-        self.mock_bmc_hw_verifier.return_value = [
+        self.mock_get_hw_tool_white_list.return_value = [
             HWTool.IPMI_SENSOR,
             HWTool.IPMI_SEL,
             HWTool.IPMI_DCMI,
@@ -313,7 +314,7 @@ class TestCharm(unittest.TestCase):
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
     def test_config_changed_update_alert_rules(self, mock_hw_tool_helper, mock_exporter):
         """Test config changed will update alert rule."""
-        self.mock_bmc_hw_verifier.return_value = [
+        self.mock_get_hw_tool_white_list.return_value = [
             HWTool.IPMI_SENSOR,
             HWTool.IPMI_SEL,
             HWTool.IPMI_DCMI,
@@ -349,7 +350,7 @@ class TestCharm(unittest.TestCase):
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
     def test_upgrade_charm_update_alert_rules(self, mock_hw_tool_helper, mock_exporter):
         """Test upgrade charm event updates alert rule."""
-        self.mock_bmc_hw_verifier.return_value = [
+        self.mock_get_hw_tool_white_list.return_value = [
             HWTool.IPMI_SENSOR,
             HWTool.IPMI_SEL,
             HWTool.IPMI_DCMI,
@@ -387,7 +388,7 @@ class TestCharm(unittest.TestCase):
         self, mock_hw_tool_helper, mock_exporter
     ) -> None:
         """Test install event when redfish is available and credential is correct."""
-        self.mock_bmc_hw_verifier.return_value = [
+        mock_enable_hw_tool_list = [
             HWTool.REDFISH,
         ]
         mock_hw_tool_helper.return_value.install.return_value = (True, "")
@@ -400,7 +401,7 @@ class TestCharm(unittest.TestCase):
         self.harness.charm.exporter.install.assert_called_with(
             10200,  # default in config.yaml
             "INFO",  # default in config.yaml
-            self.harness.charm.get_redfish_conn_params(),
+            self.harness.charm.get_redfish_conn_params(mock_enable_hw_tool_list),
             10,  # default int config.yaml
         )
 
@@ -412,7 +413,7 @@ class TestCharm(unittest.TestCase):
         self, test_exception, mock_redfish_client, mock_hw_tool_helper, mock_exporter
     ) -> None:
         """Test event install when redfish is available but credential is wrong."""
-        self.mock_bmc_hw_verifier.return_value = [
+        self.mock_get_hw_tool_white_list.return_value = [
             HWTool.REDFISH,
         ]
         mock_redfish_client.side_effect = test_exception()
@@ -438,15 +439,16 @@ class TestCharm(unittest.TestCase):
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
     @mock.patch("charm.redfish_client", return_value=mock.MagicMock())
+    @mock.patch("charm.HardwareObserverCharm._stored")
     def test_config_changed_redfish_enabled_with_incorrect_credential(
-        self, test_exception, mock_redfish_client, mock_hw_tool_helper, mock_exporter
+        self, test_exception, mock_stored, mock_redfish_client, mock_hw_tool_helper, mock_exporter
     ) -> None:
         """Test event config changed when redfish is available but credential is wrong."""
-        self.mock_bmc_hw_verifier.return_value = [
-            HWTool.IPMI_SENSOR,
-            HWTool.IPMI_SEL,
-            HWTool.IPMI_DCMI,
-            HWTool.REDFISH,
+        mock_stored.enable_hw_tool_list_values = [
+            "ipmi_sensor",
+            "ipmi_sel",
+            "ipmi_dcmi",
+            "redfish",
         ]
         mock_hw_tool_helper.return_value.install.return_value = (True, "")
         mock_hw_tool_helper.return_value.check_installed.return_value = (True, "")
@@ -459,6 +461,7 @@ class TestCharm(unittest.TestCase):
         new_config = {
             "exporter-port": 80,
             "exporter-log-level": "DEBUG",
+            "collect-timeout": 10,
             "redfish-username": "redfish",
             "redfish-password": "redfish",
         }

--- a/tests/unit/test_exporter.py
+++ b/tests/unit/test_exporter.py
@@ -46,12 +46,12 @@ class TestExporter(unittest.TestCase):
         get_bmc_address_patcher.start()
         self.addCleanup(get_bmc_address_patcher.stop)
 
-        bmc_hw_verifier_patcher = mock.patch(
-            "charm.bmc_hw_verifier",
+        get_charm_hw_tool_white_list_patcher = mock.patch(
+            "charm.get_hw_tool_white_list",
             return_value=[HWTool.IPMI_SENSOR, HWTool.IPMI_SEL, HWTool.IPMI_DCMI, HWTool.REDFISH],
         )
-        bmc_hw_verifier_patcher.start()
-        self.addCleanup(bmc_hw_verifier_patcher.stop)
+        get_charm_hw_tool_white_list_patcher.start()
+        self.addCleanup(get_charm_hw_tool_white_list_patcher.stop)
 
         redfish_client_patcher = mock.patch("charm.redfish_client")
         redfish_client_patcher.start()


### PR DESCRIPTION
The list will be created only once, during the install hook, and the same list will be reused everywhere else. This avoids generating a new list everytime it's needed, and potentially losing a hw from the list when it can't be temporarily accessed.
This way, the list of hardware being monitored is predictable.
This helps avoid issues like #202 
An action to refresh the hardware list will be provided as a future enhancement, so the operators can regenerate the hw tool list if needed. 