### PR TITLE
Store hw tool list in _stored and reuse it.

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -82,7 +82,7 @@ class HardwareObserverCharm(ops.CharmBase):
             self._stored.enabled_hw_tool_list_values = [  # type: ignore[unreachable]
                 tool.value for tool in get_hw_tool_enable_list()
             ]
-        return list(self._stored.enabled_hw_tool_list_values)  # type: ignore[call-overload]
+        return self._stored.enabled_hw_tool_list_values  # type: ignore[return-value]
 
     def get_hw_tools_from_values(self, hw_tool_values: List[str]) -> List[HWTool]:
         """Get HWTool objects from hw tool values."""

--- a/src/hw_tools.py
+++ b/src/hw_tools.py
@@ -569,9 +569,9 @@ class HWToolHelper:
             return False, f"Missing resources: {missing_resources}"
         return True, ""
 
-    def install(self, resources: Resources) -> Tuple[bool, str]:
+    def install(self, resources: Resources, enable_hw_tool_list: List[HWTool]) -> Tuple[bool, str]:
         """Install tools."""
-        hw_white_list: List[HWTool] = get_hw_tool_white_list()
+        hw_white_list: List[HWTool] = enable_hw_tool_list
         logger.info("hw_white_list: %s", hw_white_list)
 
         fetch_tools: Dict[HWTool, Path] = self.fetch_tools(resources, hw_white_list)
@@ -609,9 +609,10 @@ class HWToolHelper:
             return False, f"Fail strategies: {fail_strategies}"
         return True, ""
 
-    def remove(self, resources: Resources) -> None:  # pylint: disable=W0613
+    # pylint: disable=W0613
+    def remove(self, resources: Resources, enable_hw_tool_list: List[HWTool]) -> None:
         """Execute all remove strategies."""
-        hw_white_list: List[HWTool] = get_hw_tool_white_list()
+        hw_white_list: List[HWTool] = enable_hw_tool_list
         for strategy in self.strategies:
             if strategy.name not in hw_white_list:
                 continue
@@ -619,9 +620,9 @@ class HWToolHelper:
                 strategy.remove()
             logger.info("Strategy %s remove success", strategy)
 
-    def check_installed(self) -> Tuple[bool, str]:
+    def check_installed(self, enable_hw_tool_list: List[HWTool]) -> Tuple[bool, str]:
         """Check tool status."""
-        hw_white_list: List[HWTool] = get_hw_tool_white_list()
+        hw_white_list: List[HWTool] = enable_hw_tool_list
         failed_checks: List[HWTool] = []
 
         for strategy in self.strategies:

--- a/src/hw_tools.py
+++ b/src/hw_tools.py
@@ -503,11 +503,11 @@ def bmc_hw_verifier() -> List[HWTool]:
 # Using cache here to avoid repeat call.
 # The lru_cache should be clean everytime the hook been triggered.
 @lru_cache
-def get_hw_tool_white_list() -> List[HWTool]:
-    """Return HWTool white list."""
-    raid_white_list = raid_hw_verifier()
-    bmc_white_list = bmc_hw_verifier()
-    return raid_white_list + bmc_white_list
+def get_hw_tool_enable_list() -> List[HWTool]:
+    """Return HWTool enable list."""
+    raid_enable_list = raid_hw_verifier()
+    bmc_enable_list = bmc_hw_verifier()
+    return raid_enable_list + bmc_enable_list
 
 
 class HWToolHelper:
@@ -531,13 +531,13 @@ class HWToolHelper:
     def fetch_tools(  # pylint: disable=W0102
         self,
         resources: Resources,
-        hw_white_list: List[HWTool] = [],
+        hw_enable_list: List[HWTool] = [],
     ) -> Dict[HWTool, Path]:
         """Fetch resource from juju if it's VENDOR_TOOLS."""
         fetch_tools: Dict[HWTool, Path] = {}
         # Fetch all tools from juju resources
         for tool, resource in TPR_RESOURCES.items():
-            if tool not in hw_white_list:
+            if tool not in hw_enable_list:
                 logger.info("Skip fetch tool: %s", tool)
                 continue
             try:
@@ -549,11 +549,11 @@ class HWToolHelper:
         return fetch_tools
 
     def check_missing_resources(
-        self, hw_white_list: List[HWTool], fetch_tools: Dict[HWTool, Path]
+        self, hw_enable_list: List[HWTool], fetch_tools: Dict[HWTool, Path]
     ) -> Tuple[bool, str]:
         """Check if required resources are not been uploaded."""
         missing_resources = []
-        for tool in hw_white_list:
+        for tool in hw_enable_list:
             if tool in TPR_RESOURCES:
                 # Resource hasn't been uploaded
                 if tool not in fetch_tools:
@@ -569,14 +569,13 @@ class HWToolHelper:
             return False, f"Missing resources: {missing_resources}"
         return True, ""
 
-    def install(self, resources: Resources, enable_hw_tool_list: List[HWTool]) -> Tuple[bool, str]:
+    def install(self, resources: Resources, hw_enable_list: List[HWTool]) -> Tuple[bool, str]:
         """Install tools."""
-        hw_white_list: List[HWTool] = enable_hw_tool_list
-        logger.info("hw_white_list: %s", hw_white_list)
+        logger.info("hw_enable_list: %s", hw_enable_list)
 
-        fetch_tools: Dict[HWTool, Path] = self.fetch_tools(resources, hw_white_list)
+        fetch_tools: Dict[HWTool, Path] = self.fetch_tools(resources, hw_enable_list)
 
-        ok, msg = self.check_missing_resources(hw_white_list, fetch_tools)
+        ok, msg = self.check_missing_resources(hw_enable_list, fetch_tools)
         if not ok:
             return ok, msg
 
@@ -584,7 +583,7 @@ class HWToolHelper:
 
         # Iterate over each strategy and execute.
         for strategy in self.strategies:
-            if strategy.name not in hw_white_list:
+            if strategy.name not in hw_enable_list:
                 continue
             # TPRStrategy
             try:
@@ -610,23 +609,21 @@ class HWToolHelper:
         return True, ""
 
     # pylint: disable=W0613
-    def remove(self, resources: Resources, enable_hw_tool_list: List[HWTool]) -> None:
+    def remove(self, resources: Resources, hw_enable_list: List[HWTool]) -> None:
         """Execute all remove strategies."""
-        hw_white_list: List[HWTool] = enable_hw_tool_list
         for strategy in self.strategies:
-            if strategy.name not in hw_white_list:
+            if strategy.name not in hw_enable_list:
                 continue
             if isinstance(strategy, (TPRStrategyABC, APTStrategyABC)):
                 strategy.remove()
             logger.info("Strategy %s remove success", strategy)
 
-    def check_installed(self, enable_hw_tool_list: List[HWTool]) -> Tuple[bool, str]:
+    def check_installed(self, hw_enable_list: List[HWTool]) -> Tuple[bool, str]:
         """Check tool status."""
-        hw_white_list: List[HWTool] = enable_hw_tool_list
         failed_checks: List[HWTool] = []
 
         for strategy in self.strategies:
-            if strategy.name not in hw_white_list:
+            if strategy.name not in hw_enable_list:
                 continue
             ok = strategy.check()
             if not ok:

--- a/src/service.py
+++ b/src/service.py
@@ -17,7 +17,6 @@ from config import (
     EXPORTER_SERVICE_TEMPLATE,
     HWTool,
 )
-from hw_tools import get_hw_tool_white_list
 
 logger = getLogger(__name__)
 
@@ -93,13 +92,10 @@ class ExporterTemplate:
         level: str,
         collect_timeout: int,
         redfish_conn_params: dict,
-        enable_hw_tool_list: Union[List[HWTool], None] = None,
+        enable_hw_tool_list: List[HWTool],
     ) -> bool:
         """Render and install exporter config file."""
-        if enable_hw_tool_list is not None:
-            hw_tools = enable_hw_tool_list
-        else:
-            hw_tools = get_hw_tool_white_list()
+        hw_tools = enable_hw_tool_list
         collectors = []
         for tool in hw_tools:
             collector = EXPORTER_COLLECTOR_MAPPING.get(tool)
@@ -140,7 +136,7 @@ class Exporter:
         self.template = ExporterTemplate(charm_dir)
 
     def install(
-        self, port: int, level: str, redfish_conn_params: dict, collect_timeout: int
+        self, port: int, level: str, redfish_conn_params: dict, collect_timeout: int, enable_hw_tool_list: List
     ) -> bool:
         """Install the exporter."""
         logger.info("Installing %s.", EXPORTER_NAME)
@@ -149,6 +145,7 @@ class Exporter:
             level=level,
             redfish_conn_params=redfish_conn_params,
             collect_timeout=collect_timeout,
+            enable_hw_tool_list=enable_hw_tool_list,
         )
         success = self.template.render_service(str(self.charm_dir), str(EXPORTER_CONFIG_PATH))
         if not success:

--- a/src/service.py
+++ b/src/service.py
@@ -3,7 +3,7 @@
 from functools import wraps
 from logging import getLogger
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Tuple, Union
+from typing import Any, Callable, Dict, List, Tuple
 
 from charms.operator_libs_linux.v1 import systemd
 from jinja2 import Environment, FileSystemLoader
@@ -92,10 +92,9 @@ class ExporterTemplate:
         level: str,
         collect_timeout: int,
         redfish_conn_params: dict,
-        enable_hw_tool_list: List[HWTool],
+        hw_tools: List[HWTool],
     ) -> bool:
         """Render and install exporter config file."""
-        hw_tools = enable_hw_tool_list
         collectors = []
         for tool in hw_tools:
             collector = EXPORTER_COLLECTOR_MAPPING.get(tool)
@@ -135,8 +134,14 @@ class Exporter:
         self.charm_dir = charm_dir
         self.template = ExporterTemplate(charm_dir)
 
+    # pylint: disable=too-many-arguments
     def install(
-        self, port: int, level: str, redfish_conn_params: dict, collect_timeout: int, enable_hw_tool_list: List
+        self,
+        port: int,
+        level: str,
+        redfish_conn_params: dict,
+        collect_timeout: int,
+        hw_tool_enable_list: List,
     ) -> bool:
         """Install the exporter."""
         logger.info("Installing %s.", EXPORTER_NAME)
@@ -145,7 +150,7 @@ class Exporter:
             level=level,
             redfish_conn_params=redfish_conn_params,
             collect_timeout=collect_timeout,
-            enable_hw_tool_list=enable_hw_tool_list,
+            hw_tools=hw_tool_enable_list,
         )
         success = self.template.render_service(str(self.charm_dir), str(EXPORTER_CONFIG_PATH))
         if not success:

--- a/src/service.py
+++ b/src/service.py
@@ -3,7 +3,7 @@
 from functools import wraps
 from logging import getLogger
 from pathlib import Path
-from typing import Any, Callable, Dict, Tuple
+from typing import Any, Callable, Dict, List, Tuple, Union
 
 from charms.operator_libs_linux.v1 import systemd
 from jinja2 import Environment, FileSystemLoader
@@ -15,6 +15,7 @@ from config import (
     EXPORTER_NAME,
     EXPORTER_SERVICE_PATH,
     EXPORTER_SERVICE_TEMPLATE,
+    HWTool,
 )
 from hw_tools import get_hw_tool_white_list
 
@@ -85,11 +86,20 @@ class ExporterTemplate:
             logger.info("Removing file '%s' - Done.", path)
         return success
 
+    # pylint: disable=too-many-arguments
     def render_config(
-        self, port: int, level: str, collect_timeout: int, redfish_conn_params: dict
+        self,
+        port: int,
+        level: str,
+        collect_timeout: int,
+        redfish_conn_params: dict,
+        enable_hw_tool_list: Union[List[HWTool], None] = None,
     ) -> bool:
         """Render and install exporter config file."""
-        hw_tools = get_hw_tool_white_list()
+        if enable_hw_tool_list is not None:
+            hw_tools = enable_hw_tool_list
+        else:
+            hw_tools = get_hw_tool_white_list()
         collectors = []
         for tool in hw_tools:
             collector = EXPORTER_COLLECTOR_MAPPING.get(tool)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -121,11 +121,12 @@ class TestCharm(unittest.TestCase):
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
     def test_install_redfish_unavailable(self, mock_hw_tool_helper, mock_exporter) -> None:
         """Test install event handler when redfish is unavailable."""
-        self.mock_get_hw_tool_white_list.return_value = [
+        mock_enable_hw_tool_list = [
             HWTool.IPMI_SENSOR,
             HWTool.IPMI_SEL,
             HWTool.IPMI_DCMI,
         ]
+        self.mock_get_hw_tool_white_list.return_value = mock_enable_hw_tool_list
         mock_hw_tool_helper.return_value.install.return_value = (True, "")
         mock_exporter.return_value.install.return_value = True
         self.harness.begin()
@@ -138,6 +139,7 @@ class TestCharm(unittest.TestCase):
             "INFO",  # default in config.yaml
             {},
             10,  # default int config.yaml
+            mock_enable_hw_tool_list,
         )
 
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())
@@ -391,6 +393,7 @@ class TestCharm(unittest.TestCase):
         mock_enable_hw_tool_list = [
             HWTool.REDFISH,
         ]
+        self.mock_get_hw_tool_white_list.return_value = mock_enable_hw_tool_list
         mock_hw_tool_helper.return_value.install.return_value = (True, "")
         mock_exporter.return_value.install.return_value = True
         self.harness.begin()
@@ -403,6 +406,7 @@ class TestCharm(unittest.TestCase):
             "INFO",  # default in config.yaml
             self.harness.charm.get_redfish_conn_params(mock_enable_hw_tool_list),
             10,  # default int config.yaml
+            mock_enable_hw_tool_list,
         )
 
     @parameterized.expand([(InvalidCredentialsError), (Exception)])

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -28,15 +28,15 @@ class TestCharm(unittest.TestCase):
         self.mock_get_bmc_address.return_value = "127.0.0.1"
         self.addCleanup(get_bmc_address_patcher.stop)
 
-        bmc_hw_verifier_patcher = mock.patch.object(charm, "bmc_hw_verifier")
-        self.mock_bmc_hw_verifier = bmc_hw_verifier_patcher.start()
-        self.mock_bmc_hw_verifier.return_value = [
+        get_hw_tool_white_list_patcher = mock.patch.object(charm, "get_hw_tool_white_list")
+        self.mock_get_hw_tool_white_list = get_hw_tool_white_list_patcher.start()
+        self.mock_get_hw_tool_white_list.return_value = [
             HWTool.IPMI_SENSOR,
             HWTool.IPMI_SEL,
             HWTool.IPMI_DCMI,
             HWTool.REDFISH,
         ]
-        self.addCleanup(bmc_hw_verifier_patcher.stop)
+        self.addCleanup(get_hw_tool_white_list_patcher.stop)
 
         redfish_client_patcher = mock.patch("charm.redfish_client")
         redfish_client_patcher.start()
@@ -71,13 +71,15 @@ class TestCharm(unittest.TestCase):
         mock_hw_tool_helper.return_value.install.return_value = (True, "")
         mock_exporter.return_value.install.return_value = True
         self.harness.begin()
+        self.harness.charm._stored.enable_hw_tool_list_values = []
         self.harness.charm.on.install.emit()
 
         self.assertTrue(self.harness.charm._stored.resource_installed)
 
         self.harness.charm.exporter.install.assert_called_once()
         self.harness.charm.hw_tool_helper.install.assert_called_with(
-            self.harness.charm.model.resources
+            self.harness.charm.model.resources,
+            self.harness.charm._stored.enable_hw_tool_list_values,
         )
 
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())
@@ -87,13 +89,15 @@ class TestCharm(unittest.TestCase):
         mock_hw_tool_helper.return_value.install.return_value = (True, "")
         mock_exporter.return_value.install.return_value = True
         self.harness.begin()
+        self.harness.charm._stored.enable_hw_tool_list_values = []
         self.harness.charm.on.install.emit()
 
         self.assertTrue(self.harness.charm._stored.resource_installed)
 
         self.harness.charm.exporter.install.assert_called_once()
         self.harness.charm.hw_tool_helper.install.assert_called_with(
-            self.harness.charm.model.resources
+            self.harness.charm.model.resources,
+            self.harness.charm._stored.enable_hw_tool_list_values,
         )
 
         self.harness.charm.unit.status = ActiveStatus("Install complete")
@@ -117,7 +121,7 @@ class TestCharm(unittest.TestCase):
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
     def test_install_redfish_unavailable(self, mock_hw_tool_helper, mock_exporter) -> None:
         """Test install event handler when redfish is unavailable."""
-        self.mock_bmc_hw_verifier.return_value = [
+        self.mock_get_hw_tool_white_list.return_value = [
             HWTool.IPMI_SENSOR,
             HWTool.IPMI_SEL,
             HWTool.IPMI_DCMI,
@@ -158,7 +162,7 @@ class TestCharm(unittest.TestCase):
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
     def test_update_status_all_green(self, mock_hw_tool_helper, mock_exporter):
         """Test update_status event handler when everything is okay."""
-        self.mock_bmc_hw_verifier.return_value = [
+        self.mock_get_hw_tool_white_list.return_value = [
             HWTool.IPMI_SENSOR,
             HWTool.IPMI_SEL,
             HWTool.IPMI_DCMI,
@@ -178,7 +182,7 @@ class TestCharm(unittest.TestCase):
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
     def test_update_status_check_installed_false(self, mock_hw_tool_helper, mock_exporter):
         """Test update_status event handler when hw tool checks failed."""
-        self.mock_bmc_hw_verifier.return_value = [
+        self.mock_get_hw_tool_white_list.return_value = [
             HWTool.IPMI_SENSOR,
             HWTool.IPMI_SEL,
             HWTool.IPMI_DCMI,
@@ -198,7 +202,7 @@ class TestCharm(unittest.TestCase):
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
     def test_update_status_exporter_crashed(self, mock_hw_tool_helper, mock_exporter):
         """Test update_status."""
-        self.mock_bmc_hw_verifier.return_value = [
+        self.mock_get_hw_tool_white_list.return_value = [
             HWTool.IPMI_SENSOR,
             HWTool.IPMI_SEL,
             HWTool.IPMI_DCMI,
@@ -212,10 +216,9 @@ class TestCharm(unittest.TestCase):
         with self.assertRaises(ExporterError):
             self.harness.charm.on.update_status.emit()
 
-    @mock.patch.object(charm, "bmc_hw_verifier", return_value=[])
     @mock.patch("charm.HWToolHelper")
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())
-    def test_config_changed(self, mock_exporter, mock_hw_tool_helper, mock_bmc_hw_verifier):
+    def test_config_changed(self, mock_exporter, mock_hw_tool_helper):
         """Test config change event renders config file."""
         self.harness.begin()
         self.harness.charm._stored.resource_installed = True
@@ -233,12 +236,9 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(self.harness.charm.unit.status, ActiveStatus("Unit is ready"))
 
-    @mock.patch.object(charm, "bmc_hw_verifier", return_value=[])
     @mock.patch("charm.HWToolHelper")
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())
-    def test_config_changed_without_cos_agent_relation(
-        self, mock_exporter, mock_hw_tool_helper, mock_bmc_hw_verifier
-    ):
+    def test_config_changed_without_cos_agent_relation(self, mock_exporter, mock_hw_tool_helper):
         """Test config change event don't render config file if cos_agent relation is missing."""
         self.harness.begin()
         self.harness.charm._stored.resource_installed = True
@@ -275,7 +275,7 @@ class TestCharm(unittest.TestCase):
         mock_exporter.return_value.install.return_value = True
         self.harness.begin()
         self.harness.charm._stored.exporter_installed = True
-        print(dir(self.harness.charm.on))
+        self.harness.charm._stored.enable_hw_tool_list_values = []
         self.harness.charm.on.upgrade_charm.emit()
 
         self.assertTrue(self.harness.charm._stored.resource_installed)
@@ -283,14 +283,15 @@ class TestCharm(unittest.TestCase):
 
         self.harness.charm.exporter.install.assert_called_once()
         self.harness.charm.hw_tool_helper.install.assert_called_with(
-            self.harness.charm.model.resources
+            self.harness.charm.model.resources,
+            self.harness.charm._stored.enable_hw_tool_list_values,
         )
 
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
     def test_update_status_config_invalid(self, mock_hw_tool_helper, mock_exporter):
         """Test update_status event handler when config is invalid."""
-        self.mock_bmc_hw_verifier.return_value = [
+        self.mock_get_hw_tool_white_list.return_value = [
             HWTool.IPMI_SENSOR,
             HWTool.IPMI_SEL,
             HWTool.IPMI_DCMI,
@@ -313,7 +314,7 @@ class TestCharm(unittest.TestCase):
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
     def test_config_changed_update_alert_rules(self, mock_hw_tool_helper, mock_exporter):
         """Test config changed will update alert rule."""
-        self.mock_bmc_hw_verifier.return_value = [
+        self.mock_get_hw_tool_white_list.return_value = [
             HWTool.IPMI_SENSOR,
             HWTool.IPMI_SEL,
             HWTool.IPMI_DCMI,
@@ -349,7 +350,7 @@ class TestCharm(unittest.TestCase):
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
     def test_upgrade_charm_update_alert_rules(self, mock_hw_tool_helper, mock_exporter):
         """Test upgrade charm event updates alert rule."""
-        self.mock_bmc_hw_verifier.return_value = [
+        self.mock_get_hw_tool_white_list.return_value = [
             HWTool.IPMI_SENSOR,
             HWTool.IPMI_SEL,
             HWTool.IPMI_DCMI,
@@ -387,7 +388,7 @@ class TestCharm(unittest.TestCase):
         self, mock_hw_tool_helper, mock_exporter
     ) -> None:
         """Test install event when redfish is available and credential is correct."""
-        self.mock_bmc_hw_verifier.return_value = [
+        mock_enable_hw_tool_list = [
             HWTool.REDFISH,
         ]
         mock_hw_tool_helper.return_value.install.return_value = (True, "")
@@ -400,7 +401,7 @@ class TestCharm(unittest.TestCase):
         self.harness.charm.exporter.install.assert_called_with(
             10200,  # default in config.yaml
             "INFO",  # default in config.yaml
-            self.harness.charm.get_redfish_conn_params(),
+            self.harness.charm.get_redfish_conn_params(mock_enable_hw_tool_list),
             10,  # default int config.yaml
         )
 
@@ -412,7 +413,7 @@ class TestCharm(unittest.TestCase):
         self, test_exception, mock_redfish_client, mock_hw_tool_helper, mock_exporter
     ) -> None:
         """Test event install when redfish is available but credential is wrong."""
-        self.mock_bmc_hw_verifier.return_value = [
+        self.mock_get_hw_tool_white_list.return_value = [
             HWTool.REDFISH,
         ]
         mock_redfish_client.side_effect = test_exception()
@@ -438,15 +439,16 @@ class TestCharm(unittest.TestCase):
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
     @mock.patch("charm.redfish_client", return_value=mock.MagicMock())
+    @mock.patch("charm.HardwareObserverCharm._stored")
     def test_config_changed_redfish_enabled_with_incorrect_credential(
-        self, test_exception, mock_redfish_client, mock_hw_tool_helper, mock_exporter
+        self, test_exception, mock_stored, mock_redfish_client, mock_hw_tool_helper, mock_exporter
     ) -> None:
         """Test event config changed when redfish is available but credential is wrong."""
-        self.mock_bmc_hw_verifier.return_value = [
-            HWTool.IPMI_SENSOR,
-            HWTool.IPMI_SEL,
-            HWTool.IPMI_DCMI,
-            HWTool.REDFISH,
+        mock_stored.enable_hw_tool_list_values = [
+            "ipmi_sensor",
+            "ipmi_sel",
+            "ipmi_dcmi",
+            "redfish",
         ]
         mock_hw_tool_helper.return_value.install.return_value = (True, "")
         mock_hw_tool_helper.return_value.check_installed.return_value = (True, "")
@@ -459,6 +461,7 @@ class TestCharm(unittest.TestCase):
         new_config = {
             "exporter-port": 80,
             "exporter-log-level": "DEBUG",
+            "collect-timeout": 10,
             "redfish-username": "redfish",
             "redfish-password": "redfish",
         }

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -28,15 +28,15 @@ class TestCharm(unittest.TestCase):
         self.mock_get_bmc_address.return_value = "127.0.0.1"
         self.addCleanup(get_bmc_address_patcher.stop)
 
-        get_hw_tool_white_list_patcher = mock.patch.object(charm, "get_hw_tool_white_list")
-        self.mock_get_hw_tool_white_list = get_hw_tool_white_list_patcher.start()
-        self.mock_get_hw_tool_white_list.return_value = [
+        get_hw_tool_enable_list_patcher = mock.patch.object(charm, "get_hw_tool_enable_list")
+        self.mock_get_hw_tool_enable_list = get_hw_tool_enable_list_patcher.start()
+        self.mock_get_hw_tool_enable_list.return_value = [
             HWTool.IPMI_SENSOR,
             HWTool.IPMI_SEL,
             HWTool.IPMI_DCMI,
             HWTool.REDFISH,
         ]
-        self.addCleanup(get_hw_tool_white_list_patcher.stop)
+        self.addCleanup(get_hw_tool_enable_list_patcher.stop)
 
         redfish_client_patcher = mock.patch("charm.redfish_client")
         redfish_client_patcher.start()
@@ -71,7 +71,7 @@ class TestCharm(unittest.TestCase):
         mock_hw_tool_helper.return_value.install.return_value = (True, "")
         mock_exporter.return_value.install.return_value = True
         self.harness.begin()
-        self.harness.charm._stored.enable_hw_tool_list_values = []
+        self.harness.charm._stored.enabled_hw_tool_list_values = []
         self.harness.charm.on.install.emit()
 
         self.assertTrue(self.harness.charm._stored.resource_installed)
@@ -79,7 +79,7 @@ class TestCharm(unittest.TestCase):
         self.harness.charm.exporter.install.assert_called_once()
         self.harness.charm.hw_tool_helper.install.assert_called_with(
             self.harness.charm.model.resources,
-            self.harness.charm._stored.enable_hw_tool_list_values,
+            self.harness.charm._stored.enabled_hw_tool_list_values,
         )
 
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())
@@ -89,7 +89,7 @@ class TestCharm(unittest.TestCase):
         mock_hw_tool_helper.return_value.install.return_value = (True, "")
         mock_exporter.return_value.install.return_value = True
         self.harness.begin()
-        self.harness.charm._stored.enable_hw_tool_list_values = []
+        self.harness.charm._stored.enabled_hw_tool_list_values = []
         self.harness.charm.on.install.emit()
 
         self.assertTrue(self.harness.charm._stored.resource_installed)
@@ -97,7 +97,7 @@ class TestCharm(unittest.TestCase):
         self.harness.charm.exporter.install.assert_called_once()
         self.harness.charm.hw_tool_helper.install.assert_called_with(
             self.harness.charm.model.resources,
-            self.harness.charm._stored.enable_hw_tool_list_values,
+            self.harness.charm._stored.enabled_hw_tool_list_values,
         )
 
         self.harness.charm.unit.status = ActiveStatus("Install complete")
@@ -121,12 +121,12 @@ class TestCharm(unittest.TestCase):
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
     def test_install_redfish_unavailable(self, mock_hw_tool_helper, mock_exporter) -> None:
         """Test install event handler when redfish is unavailable."""
-        mock_enable_hw_tool_list = [
+        mock_enabled_hw_tool_list = [
             HWTool.IPMI_SENSOR,
             HWTool.IPMI_SEL,
             HWTool.IPMI_DCMI,
         ]
-        self.mock_get_hw_tool_white_list.return_value = mock_enable_hw_tool_list
+        self.mock_get_hw_tool_enable_list.return_value = mock_enabled_hw_tool_list
         mock_hw_tool_helper.return_value.install.return_value = (True, "")
         mock_exporter.return_value.install.return_value = True
         self.harness.begin()
@@ -139,7 +139,7 @@ class TestCharm(unittest.TestCase):
             "INFO",  # default in config.yaml
             {},
             10,  # default int config.yaml
-            mock_enable_hw_tool_list,
+            mock_enabled_hw_tool_list,
         )
 
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())
@@ -164,7 +164,7 @@ class TestCharm(unittest.TestCase):
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
     def test_update_status_all_green(self, mock_hw_tool_helper, mock_exporter):
         """Test update_status event handler when everything is okay."""
-        self.mock_get_hw_tool_white_list.return_value = [
+        self.mock_get_hw_tool_enable_list.return_value = [
             HWTool.IPMI_SENSOR,
             HWTool.IPMI_SEL,
             HWTool.IPMI_DCMI,
@@ -184,7 +184,7 @@ class TestCharm(unittest.TestCase):
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
     def test_update_status_check_installed_false(self, mock_hw_tool_helper, mock_exporter):
         """Test update_status event handler when hw tool checks failed."""
-        self.mock_get_hw_tool_white_list.return_value = [
+        self.mock_get_hw_tool_enable_list.return_value = [
             HWTool.IPMI_SENSOR,
             HWTool.IPMI_SEL,
             HWTool.IPMI_DCMI,
@@ -204,7 +204,7 @@ class TestCharm(unittest.TestCase):
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
     def test_update_status_exporter_crashed(self, mock_hw_tool_helper, mock_exporter):
         """Test update_status."""
-        self.mock_get_hw_tool_white_list.return_value = [
+        self.mock_get_hw_tool_enable_list.return_value = [
             HWTool.IPMI_SENSOR,
             HWTool.IPMI_SEL,
             HWTool.IPMI_DCMI,
@@ -277,7 +277,7 @@ class TestCharm(unittest.TestCase):
         mock_exporter.return_value.install.return_value = True
         self.harness.begin()
         self.harness.charm._stored.exporter_installed = True
-        self.harness.charm._stored.enable_hw_tool_list_values = []
+        self.harness.charm._stored.enabled_hw_tool_list_values = []
         self.harness.charm.on.upgrade_charm.emit()
 
         self.assertTrue(self.harness.charm._stored.resource_installed)
@@ -286,14 +286,14 @@ class TestCharm(unittest.TestCase):
         self.harness.charm.exporter.install.assert_called_once()
         self.harness.charm.hw_tool_helper.install.assert_called_with(
             self.harness.charm.model.resources,
-            self.harness.charm._stored.enable_hw_tool_list_values,
+            self.harness.charm._stored.enabled_hw_tool_list_values,
         )
 
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
     def test_update_status_config_invalid(self, mock_hw_tool_helper, mock_exporter):
         """Test update_status event handler when config is invalid."""
-        self.mock_get_hw_tool_white_list.return_value = [
+        self.mock_get_hw_tool_enable_list.return_value = [
             HWTool.IPMI_SENSOR,
             HWTool.IPMI_SEL,
             HWTool.IPMI_DCMI,
@@ -316,7 +316,7 @@ class TestCharm(unittest.TestCase):
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
     def test_config_changed_update_alert_rules(self, mock_hw_tool_helper, mock_exporter):
         """Test config changed will update alert rule."""
-        self.mock_get_hw_tool_white_list.return_value = [
+        self.mock_get_hw_tool_enable_list.return_value = [
             HWTool.IPMI_SENSOR,
             HWTool.IPMI_SEL,
             HWTool.IPMI_DCMI,
@@ -352,7 +352,7 @@ class TestCharm(unittest.TestCase):
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
     def test_upgrade_charm_update_alert_rules(self, mock_hw_tool_helper, mock_exporter):
         """Test upgrade charm event updates alert rule."""
-        self.mock_get_hw_tool_white_list.return_value = [
+        self.mock_get_hw_tool_enable_list.return_value = [
             HWTool.IPMI_SENSOR,
             HWTool.IPMI_SEL,
             HWTool.IPMI_DCMI,
@@ -390,10 +390,10 @@ class TestCharm(unittest.TestCase):
         self, mock_hw_tool_helper, mock_exporter
     ) -> None:
         """Test install event when redfish is available and credential is correct."""
-        mock_enable_hw_tool_list = [
+        mock_enabled_hw_tool_list = [
             HWTool.REDFISH,
         ]
-        self.mock_get_hw_tool_white_list.return_value = mock_enable_hw_tool_list
+        self.mock_get_hw_tool_enable_list.return_value = mock_enabled_hw_tool_list
         mock_hw_tool_helper.return_value.install.return_value = (True, "")
         mock_exporter.return_value.install.return_value = True
         self.harness.begin()
@@ -404,9 +404,9 @@ class TestCharm(unittest.TestCase):
         self.harness.charm.exporter.install.assert_called_with(
             10200,  # default in config.yaml
             "INFO",  # default in config.yaml
-            self.harness.charm.get_redfish_conn_params(mock_enable_hw_tool_list),
+            self.harness.charm.get_redfish_conn_params(mock_enabled_hw_tool_list),
             10,  # default int config.yaml
-            mock_enable_hw_tool_list,
+            mock_enabled_hw_tool_list,
         )
 
     @parameterized.expand([(InvalidCredentialsError), (Exception)])
@@ -417,7 +417,7 @@ class TestCharm(unittest.TestCase):
         self, test_exception, mock_redfish_client, mock_hw_tool_helper, mock_exporter
     ) -> None:
         """Test event install when redfish is available but credential is wrong."""
-        self.mock_get_hw_tool_white_list.return_value = [
+        self.mock_get_hw_tool_enable_list.return_value = [
             HWTool.REDFISH,
         ]
         mock_redfish_client.side_effect = test_exception()
@@ -448,7 +448,7 @@ class TestCharm(unittest.TestCase):
         self, test_exception, mock_stored, mock_redfish_client, mock_hw_tool_helper, mock_exporter
     ) -> None:
         """Test event config changed when redfish is available but credential is wrong."""
-        mock_stored.enable_hw_tool_list_values = [
+        mock_stored.enabled_hw_tool_list_values = [
             "ipmi_sensor",
             "ipmi_sel",
             "ipmi_dcmi",

--- a/tests/unit/test_exporter.py
+++ b/tests/unit/test_exporter.py
@@ -42,12 +42,12 @@ class TestExporter(unittest.TestCase):
         get_bmc_address_patcher.start()
         self.addCleanup(get_bmc_address_patcher.stop)
 
-        get_charm_hw_tool_white_list_patcher = mock.patch(
-            "charm.get_hw_tool_white_list",
+        get_charm_hw_tool_enable_list_patcher = mock.patch(
+            "charm.get_hw_tool_enable_list",
             return_value=[HWTool.IPMI_SENSOR, HWTool.IPMI_SEL, HWTool.IPMI_DCMI, HWTool.REDFISH],
         )
-        get_charm_hw_tool_white_list_patcher.start()
-        self.addCleanup(get_charm_hw_tool_white_list_patcher.stop)
+        get_charm_hw_tool_enable_list_patcher.start()
+        self.addCleanup(get_charm_hw_tool_enable_list_patcher.stop)
 
         redfish_client_patcher = mock.patch("charm.redfish_client")
         redfish_client_patcher.start()
@@ -339,7 +339,7 @@ class TestExporterTemplate(unittest.TestCase):
                 level="info",
                 redfish_conn_params={},
                 collect_timeout=10,
-                enable_hw_tool_list=[HWTool.STORCLI, HWTool.SSACLI],
+                hw_tools=[HWTool.STORCLI, HWTool.SSACLI],
             )
             mock_install.assert_called_with(
                 EXPORTER_CONFIG_PATH,
@@ -366,7 +366,7 @@ class TestExporterTemplate(unittest.TestCase):
                     "username": "default_user",
                     "password": "default_pwd",
                 },
-                enable_hw_tool_list=[HWTool.REDFISH],
+                hw_tools=[HWTool.REDFISH],
             )
             mock_install.assert_called_with(
                 EXPORTER_CONFIG_PATH,

--- a/tests/unit/test_exporter.py
+++ b/tests/unit/test_exporter.py
@@ -46,12 +46,12 @@ class TestExporter(unittest.TestCase):
         get_bmc_address_patcher.start()
         self.addCleanup(get_bmc_address_patcher.stop)
 
-        bmc_hw_verifier_patcher = mock.patch(
-            "charm.bmc_hw_verifier",
+        get_charm_hw_tool_white_list_patcher = mock.patch(
+            "charm.get_hw_tool_white_list",
             return_value=[HWTool.IPMI_SENSOR, HWTool.IPMI_SEL, HWTool.IPMI_DCMI, HWTool.REDFISH],
         )
-        bmc_hw_verifier_patcher.start()
-        self.addCleanup(bmc_hw_verifier_patcher.stop)
+        get_charm_hw_tool_white_list_patcher.start()
+        self.addCleanup(get_charm_hw_tool_white_list_patcher.stop)
 
         redfish_client_patcher = mock.patch("charm.redfish_client")
         redfish_client_patcher.start()

--- a/tests/unit/test_exporter.py
+++ b/tests/unit/test_exporter.py
@@ -38,10 +38,6 @@ class TestExporter(unittest.TestCase):
         mock_hw_tool_helper.return_value.check_installed.return_value = [True, ""]
         self.addCleanup(hw_tool_lib_patcher.stop)
 
-        get_hw_tool_white_list_patcher = mock.patch.object(service, "get_hw_tool_white_list")
-        get_hw_tool_white_list_patcher.start()
-        self.addCleanup(get_hw_tool_white_list_patcher.stop)
-
         get_bmc_address_patcher = mock.patch("charm.get_bmc_address", return_value="127.0.0.1")
         get_bmc_address_patcher.start()
         self.addCleanup(get_bmc_address_patcher.stop)
@@ -336,17 +332,14 @@ class TestExporterTemplate(unittest.TestCase):
         search_path = pathlib.Path(f"{__file__}/../../..").resolve()
         self.template = service.ExporterTemplate(search_path)
 
-    @mock.patch(
-        "service.get_hw_tool_white_list",
-        return_value=[HWTool.STORCLI, HWTool.SSACLI],
-    )
-    def test_render_config(self, mock_get_hw_tool_white_list):
+    def test_render_config(self):
         with mock.patch.object(self.template, "_install") as mock_install:
             self.template.render_config(
                 port="80",
                 level="info",
                 redfish_conn_params={},
                 collect_timeout=10,
+                enable_hw_tool_list=[HWTool.STORCLI, HWTool.SSACLI],
             )
             mock_install.assert_called_with(
                 EXPORTER_CONFIG_PATH,
@@ -362,11 +355,7 @@ class TestExporterTemplate(unittest.TestCase):
                 ),
             )
 
-    @mock.patch(
-        "service.get_hw_tool_white_list",
-        return_value=[HWTool.REDFISH],
-    )
-    def test_render_config_redfish(self, mock_get_hw_tool_white_list):
+    def test_render_config_redfish(self):
         with mock.patch.object(self.template, "_install") as mock_install:
             self.template.render_config(
                 port="80",
@@ -377,6 +366,7 @@ class TestExporterTemplate(unittest.TestCase):
                     "username": "default_user",
                     "password": "default_pwd",
                 },
+                enable_hw_tool_list=[HWTool.REDFISH],
             )
             mock_install.assert_called_with(
                 EXPORTER_CONFIG_PATH,

--- a/tests/unit/test_hw_tools.py
+++ b/tests/unit/test_hw_tools.py
@@ -41,7 +41,7 @@ from hw_tools import (
     check_deb_pkg_installed,
     copy_to_snap_common_bin,
     file_is_empty,
-    get_hw_tool_white_list,
+    get_hw_tool_enable_list,
     install_deb,
     make_executable,
     raid_hw_verifier,
@@ -141,7 +141,7 @@ class TestHWToolHelper(unittest.TestCase):
 
         self.hw_tool_helper.fetch_tools(
             resources=mock_resources,
-            hw_white_list=[tool for tool in HWTool],
+            hw_enable_list=[tool for tool in HWTool],
         )
 
         for tool in TPR_RESOURCES.values():
@@ -155,7 +155,7 @@ class TestHWToolHelper(unittest.TestCase):
 
         fetch_tools = self.hw_tool_helper.fetch_tools(
             mock_resources,
-            hw_white_list=[tool for tool in HWTool],
+            hw_enable_list=[tool for tool in HWTool],
         )
 
         for tool in TPR_RESOURCES.values():
@@ -179,11 +179,11 @@ class TestHWToolHelper(unittest.TestCase):
 
         mock_strategies.return_value[0].name = HWTool.STORCLI
 
-        mock_enable_hw_tool_list = []
+        mock_hw_enable_list = []
         for strategy in mock_strategies.return_value:
-            mock_enable_hw_tool_list.append(strategy.name)
+            mock_hw_enable_list.append(strategy.name)
 
-        self.hw_tool_helper.install(mock_resources, mock_enable_hw_tool_list)
+        self.hw_tool_helper.install(mock_resources, mock_hw_enable_list)
 
         for strategy in mock_strategies.return_value:
             if isinstance(strategy, TPRStrategyABC):
@@ -203,8 +203,8 @@ class TestHWToolHelper(unittest.TestCase):
         self.harness.begin()
         mock_resources = self.harness.charm.model.resources
         mock_strategies.return_value[0].name = HWTool.STORCLI
-        mock_enable_hw_tool_list = [HWTool.STORCLI]
-        self.hw_tool_helper.remove(mock_resources, mock_enable_hw_tool_list)
+        mock_hw_enable_list = [HWTool.STORCLI]
+        self.hw_tool_helper.remove(mock_resources, mock_hw_enable_list)
         for strategy in mock_strategies.return_value:
             strategy.remove.assert_called()
 
@@ -216,7 +216,7 @@ class TestHWToolHelper(unittest.TestCase):
         ],
         new_callable=mock.PropertyMock,
     )
-    def test_06_install_not_in_white_list(self, mock_strategies):
+    def test_06_install_not_in_enable_list(self, mock_strategies):
         """Check strategy is been called."""
         self.harness.add_resource("storcli-deb", "storcli.deb")
         self.harness.begin()
@@ -224,9 +224,9 @@ class TestHWToolHelper(unittest.TestCase):
 
         mock_strategies.return_value[0].name = HWTool.STORCLI
 
-        mock_enable_hw_tool_list = []
+        mock_hw_enable_list = []
 
-        self.hw_tool_helper.install(mock_resources, mock_enable_hw_tool_list)
+        self.hw_tool_helper.install(mock_resources, mock_hw_enable_list)
 
         for strategy in mock_strategies.return_value:
             strategy.install.assert_not_called()
@@ -245,11 +245,11 @@ class TestHWToolHelper(unittest.TestCase):
 
         mock_strategies.return_value[0].name = HWTool.STORCLI
 
-        mock_enable_hw_tool_list = []
+        mock_hw_enable_list = []
         for strategy in mock_strategies.return_value:
-            mock_enable_hw_tool_list.append(strategy.name)
+            mock_hw_enable_list.append(strategy.name)
 
-        self.hw_tool_helper.install(mock_resources, mock_enable_hw_tool_list)
+        self.hw_tool_helper.install(mock_resources, mock_hw_enable_list)
 
         for strategy in mock_strategies.return_value:
             strategy.install.assert_not_called()
@@ -261,12 +261,12 @@ class TestHWToolHelper(unittest.TestCase):
         ],
         new_callable=mock.PropertyMock,
     )
-    def test_08_remove_not_in_white_list(self, mock_strategies):
+    def test_08_remove_not_in_enable_list(self, mock_strategies):
         self.harness.begin()
         mock_resources = self.harness.charm.model.resources
         mock_strategies.return_value[0].name = HWTool.STORCLI
-        mock_enable_hw_tool_list = []
-        self.hw_tool_helper.remove(mock_resources, mock_enable_hw_tool_list)
+        mock_hw_enable_list = []
+        self.hw_tool_helper.remove(mock_resources, mock_hw_enable_list)
         for strategy in mock_strategies.return_value:
             strategy.remove.assert_not_called()
 
@@ -280,8 +280,8 @@ class TestHWToolHelper(unittest.TestCase):
     def test_09_install_required_resource_not_uploaded(self, _):
         self.harness.begin()
         mock_resources = self.harness.charm.model.resources
-        mock_enable_hw_tool_list = [HWTool.STORCLI, HWTool.PERCCLI]
-        ok, msg = self.hw_tool_helper.install(mock_resources, mock_enable_hw_tool_list)
+        mock_hw_enable_list = [HWTool.STORCLI, HWTool.PERCCLI]
+        ok, msg = self.hw_tool_helper.install(mock_resources, mock_hw_enable_list)
         self.assertFalse(ok)
         self.assertTrue("storcli-deb" in msg)
         self.assertTrue("perccli-deb" in msg)
@@ -312,13 +312,13 @@ class TestHWToolHelper(unittest.TestCase):
         mock_strategies.return_value[2].install.side_effect = apt.PackageError(
             "Fake apt package error"
         )
-        mock_enable_hw_tool_list = [
+        mock_hw_enable_list = [
             HWTool.STORCLI,
             HWTool.IPMI_SENSOR,
             HWTool.REDFISH,
         ]
 
-        ok, msg = self.hw_tool_helper.install(mock_resources, mock_enable_hw_tool_list)
+        ok, msg = self.hw_tool_helper.install(mock_resources, mock_hw_enable_list)
 
         self.assertFalse(ok)
         self.assertEqual(
@@ -330,7 +330,7 @@ class TestHWToolHelper(unittest.TestCase):
     def test_11_check_missing_resources_zero_size_resources(self, file_is_empty):
         self.harness.begin()
         ok, msg = self.hw_tool_helper.check_missing_resources(
-            hw_white_list=[HWTool.STORCLI],
+            hw_enable_list=[HWTool.STORCLI],
             fetch_tools={HWTool.STORCLI: "fake-path"},
         )
         self.assertFalse(ok)
@@ -346,8 +346,8 @@ class TestHWToolHelper(unittest.TestCase):
     def test_12_check_installed_okay(self, mock_strategies):
         self.harness.begin()
         mock_strategies.return_value[0].name = HWTool.STORCLI
-        mock_enable_hw_tool_list = [HWTool.STORCLI]
-        self.hw_tool_helper.check_installed(mock_enable_hw_tool_list)
+        mock_hw_enable_list = [HWTool.STORCLI]
+        self.hw_tool_helper.check_installed(mock_hw_enable_list)
         for strategy in mock_strategies.return_value:
             strategy.check.assert_called()
 
@@ -361,8 +361,8 @@ class TestHWToolHelper(unittest.TestCase):
     def test_13_check_installed_okay(self, mock_strategies):
         self.harness.begin()
         mock_strategies.return_value[0].name = HWTool.SSACLI
-        mock_enable_hw_tool_list = [HWTool.STORCLI]
-        success, msg = self.hw_tool_helper.check_installed(mock_enable_hw_tool_list)
+        mock_hw_enable_list = [HWTool.STORCLI]
+        success, msg = self.hw_tool_helper.check_installed(mock_hw_enable_list)
         self.assertTrue(success)
         self.assertEqual(msg, "")
 
@@ -370,7 +370,7 @@ class TestHWToolHelper(unittest.TestCase):
     @mock.patch("hw_tools.Path")
     def test_14_check_installed_not_okay(self, mock_os, mock_path):
         self.harness.begin()
-        mock_enable_hw_tool_list = [
+        mock_hw_enable_list = [
             HWTool.STORCLI,
             HWTool.PERCCLI,
             HWTool.SAS2IRCU,
@@ -381,7 +381,7 @@ class TestHWToolHelper(unittest.TestCase):
             HWTool.IPMI_DCMI,
             HWTool.REDFISH,
         ]
-        success, msg = self.hw_tool_helper.check_installed(mock_enable_hw_tool_list)
+        success, msg = self.hw_tool_helper.check_installed(mock_hw_enable_list)
         self.assertFalse(success)
 
 
@@ -730,9 +730,9 @@ class TestIPMIDCMIStrategy(unittest.TestCase):
 
 @mock.patch("hw_tools.bmc_hw_verifier", return_value=[1, 2, 3])
 @mock.patch("hw_tools.raid_hw_verifier", return_value=[4, 5, 6])
-def test_get_hw_tool_white_list(mock_raid_verifier, mock_bmc_hw_verifier):
-    get_hw_tool_white_list.cache_clear()
-    output = get_hw_tool_white_list()
+def test_get_hw_tool_enable_list(mock_raid_verifier, mock_bmc_hw_verifier):
+    get_hw_tool_enable_list.cache_clear()
+    output = get_hw_tool_enable_list()
     mock_raid_verifier.assert_called()
     mock_bmc_hw_verifier.assert_called()
     assert output == [4, 5, 6, 1, 2, 3]


### PR DESCRIPTION
The list will be created only once, during the install hook, and the same list will be reused everywhere else. This avoids generating a new list everytime it's needed, and potentially losing a hw from the list when it can't be temporarily accessed.
This way, the list of hardware being monitored is predictable.
This helps avoid issues like #202 
This also changes the 'white' list to 'enable' list. 
An action to refresh the hardware list will be provided as a future enhancement, so the operators can regenerate the hw tool list if needed. 

Setting the target as a dev  branch because this feature needs an accompanying action to regenerate hw list before it's merged to main.