### PR TITLE
[WIP]Refactor to support multiple exporters

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -3,12 +3,12 @@
 #
 
 options:
-  exporter-port:
+  hardware-exporter-port:
     type: int
     default: 10200
     description: |
-      Start the prometheus exporter at "exporter-port". By default, it will
-      start at port 10200.
+      Start the prometheus hardware exporter at "exporter-port". By default,
+      it will start at port 10200.
   exporter-log-level:
     type: string
     default: "INFO"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ distro
 ops >= 2.2.0
 jinja2
 redfish  # requests is included in this
+pydantic
 git+https://github.com/canonical/prometheus-hardware-exporter.git

--- a/src/charm.py
+++ b/src/charm.py
@@ -5,27 +5,22 @@
 """Charm the application."""
 
 import logging
-from time import sleep
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Tuple
 
 import ops
 from charms.grafana_agent.v0.cos_agent import COSAgentProvider
 from ops.framework import EventBase, StoredState
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
-from redfish import redfish_client
-from redfish.rest.v1 import InvalidCredentialsError
 
-from config import (
-    EXPORTER_CRASH_MSG,
-    EXPORTER_HEALTH_RETRY_COUNT,
-    EXPORTER_HEALTH_RETRY_TIMEOUT,
-    REDFISH_MAX_RETRY,
-    REDFISH_TIMEOUT,
-    HWTool,
+from exporter_helpers import (
+    get_exporter,
+    remove_exporter,
+    get_installed_exporters,
+    check_exporter_health,
+    reconfigure_exporter,
 )
-from hardware import get_bmc_address
-from hw_tools import HWToolHelper, bmc_hw_verifier
-from service import Exporter, ExporterError
+from hw_tools import HWToolHelper
+from service import HardwareExporter
 
 logger = logging.getLogger(__name__)
 
@@ -47,13 +42,18 @@ class HardwareObserverCharm(ops.CharmBase):
             self,
             refresh_events=[self.on.config_changed, self.on.upgrade_charm],
             metrics_endpoints=[
-                {"path": "/metrics", "port": int(self.model.config["exporter-port"])}
+                {"path": "/metrics", "port": int(self.model.config["hardware-exporter-port"])}
             ],
             # Setting scrape_timeout as collect_timeout in the `duration` format specified in
             # https://prometheus.io/docs/prometheus/latest/configuration/configuration/#duration
             scrape_configs=[{"scrape_timeout": f"{int(self.model.config['collect-timeout'])}s"}],
         )
-        self.exporter = Exporter(self.charm_dir)
+
+        self.exporters = []
+
+        hardware_exporter = get_exporter(HardwareExporter(self.charm_dir, self.model.config))
+        if hardware_exporter:
+            self.exporters.append(hardware_exporter)
 
         self.framework.observe(self.on.config_changed, self._on_config_changed)
         self.framework.observe(self.on.install, self._on_install_or_upgrade)
@@ -68,7 +68,6 @@ class HardwareObserverCharm(ops.CharmBase):
         )
 
         self._stored.set_default(
-            exporter_installed=False,
             resource_installed=False,
         )
         self.num_cos_agent_relations = self.get_num_cos_agent_relations("cos-agent")
@@ -85,20 +84,6 @@ class HardwareObserverCharm(ops.CharmBase):
             self.model.unit.status = BlockedStatus(msg)
             return
 
-        # Install exporter
-        self.model.unit.status = MaintenanceStatus("Installing exporter...")
-        success = self.exporter.install(
-            int(self.model.config["exporter-port"]),
-            self.model.config["exporter-log-level"],
-            self.get_redfish_conn_params(),
-            int(self.model.config["collect-timeout"]),
-        )
-        self._stored.exporter_installed = success
-        if not success:
-            msg = "Failed to install exporter, please refer to `juju debug-log`"
-            logger.error(msg)
-            self.model.unit.status = BlockedStatus(msg)
-            return
         self._on_update_status(event)
 
     def _on_remove(self, _: EventBase) -> None:
@@ -107,14 +92,10 @@ class HardwareObserverCharm(ops.CharmBase):
         # Remove binary tool
         self.hw_tool_helper.remove(self.model.resources)
         self._stored.resource_installed = False
-        success = self.exporter.uninstall()
-        if not success:
-            msg = "Failed to uninstall exporter, please refer to `juju debug-log`"
-            # we probably don't need to set any status here because the charm
-            # will go away soon, so only logging is enough
-            logger.warning(msg)
-        self._stored.exporter_installed = not success
-        logger.info("Remove complete")
+
+        # Remove exporters
+        for exporter in self.exporters:
+            remove_exporter(exporter, self.model)
 
     def _on_update_status(self, _: EventBase) -> None:  # noqa: C901
         """Update the charm's status."""
@@ -122,7 +103,7 @@ class HardwareObserverCharm(ops.CharmBase):
             # The charm should be in BlockedStatus with install failed msg
             return  # type: ignore[unreachable]
 
-        if not self.exporter_enabled:
+        if not self.cos_agent_related:
             self.model.unit.status = BlockedStatus("Missing relation: [cos-agent]")
             return
 
@@ -130,7 +111,7 @@ class HardwareObserverCharm(ops.CharmBase):
             self.model.unit.status = BlockedStatus("Cannot relate to more than one grafana-agent")
             return
 
-        config_valid, config_valid_message = self.validate_exporter_configs()
+        config_valid, config_valid_message = self.validate_configs()
         if not config_valid:
             self.model.unit.status = BlockedStatus(config_valid_message)
             return
@@ -140,29 +121,13 @@ class HardwareObserverCharm(ops.CharmBase):
             self.model.unit.status = BlockedStatus(error_msg)
             return
 
-        if not self.exporter.check_health():
-            logger.warning("Exporter health check - failed.")
-            # if restart isn't successful, an ExporterError exception will be raised here
-            self.restart_exporter()
+        # Check health of all exporters
+        exporters_health = [
+            check_exporter_health(exporter, self.model) for exporter in self.exporters
+        ]
 
-        self.model.unit.status = ActiveStatus("Unit is ready")
-
-    def restart_exporter(self) -> None:
-        """Restart exporter service with retry."""
-        try:
-            for i in range(1, EXPORTER_HEALTH_RETRY_COUNT + 1):
-                logger.warning("Restarting exporter - %d retry", i)
-                self.exporter.restart()
-                sleep(EXPORTER_HEALTH_RETRY_TIMEOUT)
-                if self.exporter.check_active():
-                    logger.info("Exporter active after restart.")
-                    break
-            if not self.exporter.check_active():
-                logger.error("Failed to restart the exporter.")
-                raise ExporterError(EXPORTER_CRASH_MSG)
-        except Exception as err:  # pylint: disable=W0718
-            logger.error("Exporter crashed unexpectedly: %s", err)
-            raise ExporterError(EXPORTER_CRASH_MSG) from err
+        if all(exporters_health):
+            self.model.unit.status = ActiveStatus("Unit is ready")
 
     def _on_config_changed(self, event: EventBase) -> None:
         """Reconfigure charm."""
@@ -173,23 +138,14 @@ class HardwareObserverCharm(ops.CharmBase):
             )
             event.defer()
 
-        if self.exporter_enabled:
-            success, message = self.validate_exporter_configs()
+        if self.cos_agent_related:
+            success, message = self.validate_configs()
             if not success:
                 self.model.unit.status = BlockedStatus(message)
                 return
 
-            success = self.exporter.template.render_config(
-                port=int(self.model.config["exporter-port"]),
-                level=self.model.config["exporter-log-level"],
-                redfish_conn_params=self.get_redfish_conn_params(),
-                collect_timeout=int(self.model.config["collect-timeout"]),
-            )
-            if not success:
-                message = "Failed to configure exporter, please check if the server is healthy."
-                self.model.unit.status = BlockedStatus(message)
-                return
-            self.exporter.restart()
+            for exporter in self.exporters:
+                reconfigure_exporter(exporter, self.model)
 
         self._on_update_status(event)
 
@@ -197,70 +153,50 @@ class HardwareObserverCharm(ops.CharmBase):
         """Start the exporter when relation joined."""
         if (
             not self._stored.resource_installed  # type: ignore[truthy-function]
-            or not self._stored.exporter_installed  # type: ignore[truthy-function]
+            or not get_installed_exporters(self.exporters)
         ):
             logger.info(  # type: ignore[unreachable]
-                "Defer cos-agent relation join because exporter or resources is not ready yet."
+                "Defer cos-agent relation join because exporters or resources are not ready yet."
             )
             event.defer()
             return
-        self.exporter.enable()
-        self.exporter.start()
-        logger.info("Start and enable exporter service")
+
+        for exporter in self.exporters:
+            exporter.enable_and_start()
+            logger.info(f"Enabled and started {exporter.exporter_name} service")
+
         self._on_update_status(event)
 
     def _on_cos_agent_relation_departed(self, event: EventBase) -> None:
-        """Remove the exporter when relation departed."""
-        if self._stored.exporter_installed:  # type: ignore[truthy-function]
-            self.exporter.stop()
-            self.exporter.disable()
-            logger.info("Stop and disable exporter service")
+        """Remove the exporters when relation departed."""
+
+        for exporter in self.exporters:
+            exporter.disable_and_stop()
+            logger.info(f"Disabled and stopped {exporter.exporter_name} service")
+
         self._on_update_status(event)
-
-    def get_redfish_conn_params(self) -> Dict[str, Any]:
-        """Get redfish connection parameters if redfish is available."""
-        bmc_tools = bmc_hw_verifier()
-        if HWTool.REDFISH not in bmc_tools:
-            logger.warning("Redfish unavailable, disregarding redfish config options...")
-            return {}
-        return {
-            "host": f"https://{get_bmc_address()}",
-            "username": self.model.config.get("redfish-username", ""),
-            "password": self.model.config.get("redfish-password", ""),
-            "timeout": self.model.config.get("collect-timeout"),
-        }
-
-    def validate_exporter_configs(self) -> Tuple[bool, str]:
-        """Validate the static and runtime config options for the exporter."""
-        port = int(self.model.config["exporter-port"])
-        if not 1 <= port <= 65535:
-            logger.error("Invalid exporter-port: port must be in [1, 65535].")
-            return False, "Invalid config: 'exporter-port'"
-
-        level = self.model.config["exporter-log-level"]
-        allowed_choices = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
-        if level.upper() not in allowed_choices:
-            logger.error(
-                "Invalid exporter-log-level: level must be in %s (case-insensitive).",
-                allowed_choices,
-            )
-            return False, "Invalid config: 'exporter-log-level'"
-
-        # Note we need to use `is False` because `None` means redfish is not
-        # available.
-        if self.redfish_conn_params_valid is False:
-            logger.error("Invalid redfish credentials.")
-            return False, "Invalid config: 'redfish-username' or 'redfish-password'"
-
-        return True, "Exporter config is valid."
 
     def get_num_cos_agent_relations(self, relation_name: str) -> int:
         """Get the number of relation given a relation_name."""
         relations = self.model.relations.get(relation_name, [])
         return len(relations)
 
+    def validate_configs(self) -> Tuple[bool, str]:
+        """Validate the static and runtime config options for the charm."""
+        exporter_ports = []
+        for exporter in self.exporters:
+            exporter_ports.append(exporter.port)
+            config_valid, config_valid_message = exporter.validate_exporter_configs()
+            if not config_valid:
+                return config_valid, config_valid_message
+
+        if len(exporter_ports) > len(set(exporter_ports)):
+            return False, "Ports must be unique for each exporter."
+
+        return True, "Charm config is valid."
+
     @property
-    def exporter_enabled(self) -> bool:
+    def cos_agent_related(self) -> bool:
         """Return True if cos-agent relation is present."""
         return self.num_cos_agent_relations != 0
 
@@ -268,44 +204,6 @@ class HardwareObserverCharm(ops.CharmBase):
     def too_many_cos_agent_relations(self) -> bool:
         """Return True if there're more than one cos-agent relation."""
         return self.num_cos_agent_relations > 1
-
-    @property
-    def redfish_conn_params_valid(self) -> Optional[bool]:
-        """Check if redfish connections parameters is valid or not.
-
-        If the redfish connection params is not available this property returns
-        None. Otherwise, it verifies the connection parameters. If the redfish
-        connection parameters are valid, it returns True; if not valid, it
-        returns False.
-        """
-        redfish_conn_params = self.get_redfish_conn_params()
-        if not redfish_conn_params:
-            return None
-
-        redfish_obj = None
-        try:
-            redfish_obj = redfish_client(
-                base_url=redfish_conn_params.get("host", ""),
-                username=redfish_conn_params.get("username", ""),
-                password=redfish_conn_params.get("password", ""),
-                timeout=redfish_conn_params.get("timeout", REDFISH_TIMEOUT),
-                max_retry=REDFISH_MAX_RETRY,
-            )
-            redfish_obj.login(auth="session")
-        except InvalidCredentialsError as e:
-            result = False
-            logger.error("invalid redfish credential: %s", str(e))
-        except Exception as e:  # pylint: disable=W0718
-            result = False
-            logger.error("cannot connect to redfish: %s", str(e))
-        else:
-            result = True
-        finally:
-            # Make sure to close connection at the end
-            if redfish_obj:
-                redfish_obj.logout()
-
-        return result
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/src/config.py
+++ b/src/config.py
@@ -3,20 +3,31 @@
 import typing as t
 from enum import Enum
 from pathlib import Path
+from pydantic import BaseModel
 
-# Exporter
-EXPORTER_NAME = "hardware-exporter"
-EXPORTER_CONFIG_PATH = Path(f"/etc/{EXPORTER_NAME}-config.yaml")
-EXPORTER_SERVICE_PATH = Path(f"/etc/systemd/system/{EXPORTER_NAME}.service")
-EXPORTER_CONFIG_TEMPLATE = f"{EXPORTER_NAME}-config.yaml.j2"
-EXPORTER_SERVICE_TEMPLATE = f"{EXPORTER_NAME}.service.j2"
-EXPORTER_HEALTH_RETRY_COUNT = 3
-EXPORTER_HEALTH_RETRY_TIMEOUT = 3
-EXPORTER_CRASH_MSG = "Exporter crashed unexpectedly, please refer to systemd logs..."
 
-# Redfish
-REDFISH_TIMEOUT = 10
-REDFISH_MAX_RETRY = 2
+class ExporterSettings(BaseModel):
+    """Constant settings common across exporters"""
+
+    health_retry_count: int = 3
+    health_retry_timeout: int = 3
+
+
+class HardwareExporterSettings(ExporterSettings):
+    """Constant settings for Hardware Exporter."""
+
+    name: str = "hardware-exporter"
+    config_path: Path = Path(f"/etc/{name}-config.yaml")
+    service_path: Path = Path(f"/etc/systemd/system/{name}.service")
+    config_template: str = f"{name}-config.yaml.j2"
+    service_template: str = f"{name}.service.j2"
+    crash_msg: str = "Hardware exporter crashed unexpectedly, please refer to systemd logs..."
+
+    redfish_timeout: int = 10
+    redfish_max_retry: int = 2
+
+
+HARDWARE_EXPORTER_SETTINGS = HardwareExporterSettings()
 
 
 class SystemVendor(str, Enum):
@@ -55,7 +66,7 @@ TPR_RESOURCES: t.Dict[HWTool, str] = {
     HWTool.SAS3IRCU: "sas3ircu-bin",
 }
 
-EXPORTER_COLLECTOR_MAPPING = {
+HARDWARE_EXPORTER_COLLECTOR_MAPPING = {
     HWTool.STORCLI: ["collector.mega_raid"],
     HWTool.PERCCLI: ["collector.poweredge_raid"],
     HWTool.SAS2IRCU: ["collector.lsi_sas_2"],
@@ -70,4 +81,4 @@ EXPORTER_COLLECTOR_MAPPING = {
 TOOLS_DIR = Path("/usr/sbin")
 
 # SNAP environment
-SNAP_COMMON = Path(f"/var/snap/{EXPORTER_NAME}/common")
+SNAP_COMMON = Path(f"/var/snap/{HARDWARE_EXPORTER_SETTINGS.name}/common")

--- a/src/exporter_helpers.py
+++ b/src/exporter_helpers.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Helper functions for the charm to manage exporter lifecycle.
+from logging import getLogger
+from time import sleep
+from typing import List
+
+from ops.model import BlockedStatus, MaintenanceStatus
+
+from service import BaseExporter, ExporterError
+
+logger = getLogger(__name__)
+
+
+def get_exporter(exporter: BaseExporter):
+    """Install and get an exporter"""
+    installed = exporter.install()
+    if not installed:
+        logger.error(f"Failed to install {exporter.exporter_name}")
+        return
+
+    return exporter
+
+
+def remove_exporter(exporter: BaseExporter, model):
+    """Uninstall an exporter."""
+    model.unit.status = MaintenanceStatus(f"Removing {exporter.exporter_name}...")
+    exporter.uninstall()
+    logger.info(f"Removed {exporter.exporter_name}.")
+
+
+def get_installed_exporters(all_exporters) -> List:
+    """Get a list of installed exporters."""
+    installed_exporters = []
+    for exporter in all_exporters:
+        if exporter.exporter_service_path.exists():
+            installed_exporters.append(exporter)
+
+    return installed_exporters
+
+
+def check_exporter_health(exporter: BaseExporter, model) -> bool:
+    """Check exporter health."""
+    if not exporter.check_health():
+        logger.warning(f"{exporter.exporter_name} - Exporter health check failed.")
+        try:
+            restart_exporter(
+                exporter,
+                exporter.settings.health_retry_count,
+                exporter.settings.health_retry_timeout,
+            )
+        except ExporterError as e:
+            msg = f"Exporter {exporter.exporter_name} crashed unexpectedly: {e}"
+            logger.error(msg)
+            # Setting the status as blocked instead of error
+            # since other exporters may still be healthy.
+            model.unit.status = BlockedStatus(msg)
+            return False
+
+    return True
+
+
+def restart_exporter(exporter, retry_count, retry_timeout):
+    """Restart exporter service with retry."""
+    logger.info(f"Restarting exporter - {exporter.exporter_name}")
+    try:
+        for i in range(1, retry_count + 1):
+            logger.warning("Restarting exporter - %d retry", i)
+            exporter.restart()
+            sleep(retry_timeout)
+            if exporter.check_active():
+                logger.info(f"Exporter - {exporter.exporter_name} active after restart.")
+                break
+        if not exporter.check_active():
+            logger.error(f"Failed to restart exporter - {exporter.exporter_name}.")
+            raise ExporterError()
+    except Exception as err:  # pylint: disable=W0718
+        logger.error(f"Exporter {exporter.exporter_name} crashed unexpectedly: %s", err)
+        raise ExporterError() from err
+
+
+def reconfigure_exporter(exporter: BaseExporter, model) -> bool:
+    """Reconfigure an exporter."""
+    exporter.set_config(model.config)
+    success = exporter.render_config()
+    if not success:
+        message = f"Failed to configure {exporter.exporter_name}, please check if the server is healthy."
+        model.unit.status = BlockedStatus(message)
+        return False
+    exporter.restart()
+    return True

--- a/src/hw_tools.py
+++ b/src/hw_tools.py
@@ -28,7 +28,7 @@ from checksum import (
     validate_checksum,
 )
 from config import (
-    REDFISH_TIMEOUT,
+    HARDWARE_EXPORTER_SETTINGS,
     SNAP_COMMON,
     TOOLS_DIR,
     TPR_RESOURCES,
@@ -441,7 +441,9 @@ def redfish_available() -> bool:
     bmc_address = get_bmc_address()
     health_check_endpoint = f"https://{bmc_address}:443/redfish/v1/"
     try:
-        response = requests.get(health_check_endpoint, verify=False, timeout=REDFISH_TIMEOUT)
+        response = requests.get(
+            health_check_endpoint, verify=False, timeout=HARDWARE_EXPORTER_SETTINGS.redfish_timeout
+        )
         response.raise_for_status()
         data = response.json()
         # only check if the data is empty dict or not

--- a/src/service.py
+++ b/src/service.py
@@ -1,42 +1,24 @@
 """Exporter service helper."""
 
-from functools import wraps
+from abc import ABC, abstractmethod
 from logging import getLogger
 from pathlib import Path
-from typing import Any, Callable, Dict, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 from charms.operator_libs_linux.v1 import systemd
 from jinja2 import Environment, FileSystemLoader
+from redfish import redfish_client
+from redfish.rest.v1 import InvalidCredentialsError
 
 from config import (
-    EXPORTER_COLLECTOR_MAPPING,
-    EXPORTER_CONFIG_PATH,
-    EXPORTER_CONFIG_TEMPLATE,
-    EXPORTER_NAME,
-    EXPORTER_SERVICE_PATH,
-    EXPORTER_SERVICE_TEMPLATE,
+    HARDWARE_EXPORTER_COLLECTOR_MAPPING,
+    ExporterSettings,
+    HARDWARE_EXPORTER_SETTINGS,
 )
-from hw_tools import get_hw_tool_white_list
+from hardware import get_bmc_address
+from hw_tools import get_hw_tool_white_list, bmc_hw_verifier, HWTool
 
 logger = getLogger(__name__)
-
-
-def check_installed(func: Callable) -> Callable:
-    """Ensure exporter service and exporter config is installed before running operations."""
-
-    @wraps(func)
-    def wrapper(self: Any, *args: Tuple[Any], **kwargs: Dict[str, Any]) -> Any:
-        """Wrap func."""
-        config_path = Path(EXPORTER_CONFIG_PATH)
-        service_path = Path(EXPORTER_SERVICE_PATH)
-        if not config_path.exists() or not service_path.exists():
-            logger.error("Exporter is not installed properly.")
-            logger.error("Failed to run '%s'", func.__name__)
-            return False
-        return_value = func(self, *args, **kwargs)
-        return return_value
-
-    return wrapper
 
 
 class ExporterError(Exception):
@@ -46,152 +28,247 @@ class ExporterError(Exception):
     """
 
 
-class ExporterTemplate:
-    """Jinja template helper class for exporter."""
+class BaseExporter(ABC):
+    """A class representing the exporter and the metric endpoints."""
 
-    def __init__(self, search_path: Path):
-        """Initialize template class."""
-        self.environment = Environment(loader=FileSystemLoader(search_path / "templates"))
-        self.config_template = self.environment.get_template(EXPORTER_CONFIG_TEMPLATE)
-        self.service_template = self.environment.get_template(EXPORTER_SERVICE_TEMPLATE)
+    def __init__(self, charm_dir: Path, config: Dict, settings: ExporterSettings) -> None:
+        """Initialize the Exporter class."""
+        self.charm_dir = charm_dir
 
-    def _install(self, path: Path, content: str) -> bool:
-        """Install file."""
-        success = True
-        try:
-            logger.info("Writing file to %s.", path)
-            with open(path, "w", encoding="utf-8") as file:
-                file.write(content)
-        except (NotADirectoryError, PermissionError) as err:
-            logger.error(err)
-            logger.info("Writing file to %s - Failed.", path)
-            success = False
-        else:
-            logger.info("Writing file to %s - Done.", path)
-        return success
+        self.port: int
 
-    def _uninstall(self, path: Path) -> bool:
-        """Uninstall file."""
-        success = True
-        try:
-            logger.info("Removing file '%s'.", path)
-            if path.exists():
-                path.unlink()
-        except PermissionError as err:
-            logger.error(err)
-            logger.info("Removing file '%s' - Failed.", path)
-            success = False
-        else:
-            logger.info("Removing file '%s' - Done.", path)
-        return success
+        self.settings = settings
+        self.environment = Environment(loader=FileSystemLoader(charm_dir / "templates"))
+        self.config_template = self.environment.get_template(self.settings.config_template)
+        self.service_template = self.environment.get_template(self.settings.service_template)
+        self.exporter_service_path = self.settings.service_path
+        self.exporter_config_path = self.settings.config_path
+        self.exporter_name = self.settings.name
 
-    def render_config(
-        self, port: int, level: str, collect_timeout: int, redfish_conn_params: dict
-    ) -> bool:
-        """Render and install exporter config file."""
-        hw_tools = get_hw_tool_white_list()
-        collectors = []
-        for tool in hw_tools:
-            collector = EXPORTER_COLLECTOR_MAPPING.get(tool)
-            if collector is not None:
-                collectors += collector
-        content = self.config_template.render(
-            PORT=port,
-            LEVEL=level,
-            COLLECT_TIMEOUT=collect_timeout,
-            COLLECTORS=collectors,
-            REDFISH_ENABLE=redfish_conn_params != {},
-            REDFISH_HOST=redfish_conn_params.get("host", ""),
-            REDFISH_USERNAME=redfish_conn_params.get("username", ""),
-            REDFISH_PASSWORD=redfish_conn_params.get("password", ""),
-            REDFISH_CLIENT_TIMEOUT=redfish_conn_params.get("timeout", ""),
-        )
-        return self._install(EXPORTER_CONFIG_PATH, content)
+        self.level = config["exporter-log-level"]
 
     def render_service(self, charm_dir: str, config_file: str) -> bool:
         """Render and install exporter service file."""
         content = self.service_template.render(CHARMDIR=charm_dir, CONFIG_FILE=config_file)
-        return self._install(EXPORTER_SERVICE_PATH, content)
+        return write_to_file(self.exporter_service_path, content)
+
+    def render_config(self):
+        """Render and install exporter config file."""
+        content = self._render_config_content()
+        return write_to_file(self.exporter_config_path, content)
+
+    @abstractmethod
+    def _render_config_content(self) -> str:
+        """Render config file content."""
+
+    @abstractmethod
+    def set_config(self):
+        """Set the relevant config options."""
+
+    @abstractmethod
+    def validate_exporter_configs(self) -> Tuple[bool, str]:
+        """Validate the static and runtime config options for the exporter."""
 
     def remove_config(self) -> bool:
         """Remove exporter config file."""
-        return self._uninstall(EXPORTER_CONFIG_PATH)
+        return remove_file(self.exporter_config_path)
 
     def remove_service(self) -> bool:
         """Remove exporter service file."""
-        return self._uninstall(EXPORTER_SERVICE_PATH)
+        return remove_file(self.exporter_service_path)
 
+    def restart(self) -> None:
+        """Restart the exporter daemon."""
+        systemd.service_restart(self.exporter_name)
 
-class Exporter:
-    """A class representing the exporter and the metric endpoints."""
+    def enable_and_start(self) -> None:
+        """Enable and start the exporter service."""
+        systemd.service_enable(self.exporter_name)
+        systemd.service_start(self.exporter_name)
 
-    def __init__(self, charm_dir: Path) -> None:
-        """Initialize the class."""
-        self.charm_dir = charm_dir
-        self.template = ExporterTemplate(charm_dir)
+    def disable_and_stop(self) -> None:
+        """Disable and stop the exporter service."""
+        systemd.service_disable(self.exporter_name)
+        systemd.service_stop(self.exporter_name)
 
-    def install(
-        self, port: int, level: str, redfish_conn_params: dict, collect_timeout: int
-    ) -> bool:
+    def check_active(self) -> bool:
+        """Check if the exporter is active or not."""
+        return systemd.service_running(self.exporter_name)
+
+    def check_health(self) -> bool:
+        """Check if the exporter daemon is healthy or not."""
+        return not systemd.service_failed(self.exporter_name)
+
+    def install(self) -> bool:
         """Install the exporter."""
-        logger.info("Installing %s.", EXPORTER_NAME)
-        success = self.template.render_config(
-            port=port,
-            level=level,
-            redfish_conn_params=redfish_conn_params,
-            collect_timeout=collect_timeout,
-        )
-        success = self.template.render_service(str(self.charm_dir), str(EXPORTER_CONFIG_PATH))
-        if not success:
-            logger.error("Failed to install %s.", EXPORTER_NAME)
-            return success
+        logger.info("Installing %s.", self.exporter_name)
+        config_success = self.render_config()
+        service_success = self.render_service(str(self.charm_dir), str(self.exporter_config_path))
+        if not (config_success and service_success):
+            logger.error("Failed to install %s.", self.exporter_name)
+            return False
         systemd.daemon_reload()
-        logger.info("%s installed.", EXPORTER_NAME)
-        return success
+
+        # Verify installed
+        if not (self.exporter_config_path.exists() and self.exporter_service_path.exists()):
+            logger.error(f"{self.exporter_name} is not installed properly.")
+            return False
+
+        logger.info("%s installed.", self.exporter_name)
+        return True
 
     def uninstall(self) -> bool:
         """Uninstall the exporter."""
-        logger.info("Uninstalling %s.", EXPORTER_NAME)
-        success = self.template.remove_config()
-        success = self.template.remove_service()
-        if not success:
-            logger.error("Failed to uninstall %s.", EXPORTER_NAME)
-            return success
+        logger.info("Uninstalling %s.", self.exporter_name)
+        config_success = self.remove_config()
+        service_success = self.remove_service()
+        if not (config_success and service_success):
+            logger.error("Failed to uninstall %s.", self.exporter_name)
+            return False
         systemd.daemon_reload()
-        logger.info("%s uninstalled.", EXPORTER_NAME)
-        return success
+        logger.info("%s uninstalled.", self.exporter_name)
+        return True
 
-    @check_installed
-    def stop(self) -> None:
-        """Stop the exporter daemon."""
-        systemd.service_stop(EXPORTER_NAME)
 
-    @check_installed
-    def start(self) -> None:
-        """Start the exporter daemon."""
-        systemd.service_start(EXPORTER_NAME)
+def write_to_file(path: Path, content: str) -> bool:
+    """Write to file with provided content."""
+    success = True
+    try:
+        logger.info("Writing file to %s.", path)
+        with open(path, "w", encoding="utf-8") as file:
+            file.write(content)
+    except (NotADirectoryError, PermissionError) as err:
+        logger.error(err)
+        logger.info("Writing file to %s - Failed.", path)
+        success = False
+    else:
+        logger.info("Writing file to %s - Done.", path)
+    return success
 
-    @check_installed
-    def restart(self) -> None:
-        """Restart the exporter daemon."""
-        systemd.service_restart(EXPORTER_NAME)
 
-    @check_installed
-    def enable(self) -> None:
-        """Enable the exporter service."""
-        systemd.service_enable(EXPORTER_NAME)
+def remove_file(path: Path) -> bool:
+    """Remove file."""
+    success = True
+    try:
+        logger.info("Removing file '%s'.", path)
+        if path.exists():
+            path.unlink()
+    except PermissionError as err:
+        logger.error(err)
+        logger.info("Removing file '%s' - Failed.", path)
+        success = False
+    else:
+        logger.info("Removing file '%s' - Done.", path)
+    return success
 
-    @check_installed
-    def disable(self) -> None:
-        """Restart the exporter service."""
-        systemd.service_disable(EXPORTER_NAME)
 
-    @check_installed
-    def check_active(self) -> bool:
-        """Check if the exporter is active or not."""
-        return systemd.service_running(EXPORTER_NAME)
+class HardwareExporter(BaseExporter):
+    """A class representing the hardware exporter and the metric endpoints."""
 
-    @check_installed
-    def check_health(self) -> bool:
-        """Check if the exporter daemon is healthy or not."""
-        return not systemd.service_failed(EXPORTER_NAME)
+    def __init__(self, charm_dir: Path, config: Dict) -> None:
+        """Initialize the Hardware Exporter class."""
+        super().__init__(charm_dir, config, HARDWARE_EXPORTER_SETTINGS)
+
+        self.port = int(config["hardware-exporter-port"])
+
+        self.redfish_conn_params = self.get_redfish_conn_params(config)
+        self.collect_timeout = int(config["collect-timeout"])
+
+    def _render_config_content(self) -> str:
+        """Render and install exporter config file."""
+        hw_tools = get_hw_tool_white_list()
+        collectors = []
+        for tool in hw_tools:
+            collector = HARDWARE_EXPORTER_COLLECTOR_MAPPING.get(tool)
+            if collector is not None:
+                collectors += collector
+        content = self.config_template.render(
+            PORT=self.port,
+            LEVEL=self.level,
+            COLLECT_TIMEOUT=self.collect_timeout,
+            COLLECTORS=collectors,
+            REDFISH_ENABLE=self.redfish_conn_params != {},
+            REDFISH_HOST=self.redfish_conn_params.get("host", ""),
+            REDFISH_USERNAME=self.redfish_conn_params.get("username", ""),
+            REDFISH_PASSWORD=self.redfish_conn_params.get("password", ""),
+            REDFISH_CLIENT_TIMEOUT=self.redfish_conn_params.get("timeout", ""),
+        )
+        return content
+
+    def set_config(self, config):
+        """Set the exporter relevant config options."""
+        self.port = int(config["hardware-exporter-port"])
+        self.level = config["exporter-log-level"]
+        self.redfish_conn_params = self.get_redfish_conn_params(config)
+        self.collect_timeout = int(config["collect-timeout"])
+
+    def validate_exporter_configs(self) -> Tuple[bool, str]:
+        """Validate the static and runtime config options for the exporter."""
+        if not 1 <= self.port <= 65535:
+            logger.error("Invalid hardware-exporter-port: port must be in [1, 65535].")
+            return False, "Invalid config: 'hardware-exporter-port'"
+
+        allowed_level_choices = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
+        if self.level.upper() not in allowed_level_choices:
+            logger.error(
+                "Invalid exporter-log-level: level must be in %s (case-insensitive).",
+                allowed_level_choices,
+            )
+            return False, "Invalid config: 'exporter-log-level'"
+
+        # Note we need to use `is False` because `None` means redfish is not
+        # available.
+        if self.redfish_conn_params_valid(self.redfish_conn_params) is False:
+            logger.error("Invalid redfish credentials.")
+            return False, "Invalid config: 'redfish-username' or 'redfish-password'"
+
+        return True, "Exporter config is valid."
+
+    def redfish_conn_params_valid(self, redfish_conn_params) -> Optional[bool]:
+        """Check if redfish connections parameters is valid or not.
+
+        If the redfish connection params is not available this property returns
+        None. Otherwise, it verifies the connection parameters. If the redfish
+        connection parameters are valid, it returns True; if not valid, it
+        returns False.
+        """
+        if not redfish_conn_params:
+            return None
+
+        redfish_obj = None
+        try:
+            redfish_obj = redfish_client(
+                base_url=redfish_conn_params.get("host", ""),
+                username=redfish_conn_params.get("username", ""),
+                password=redfish_conn_params.get("password", ""),
+                timeout=redfish_conn_params.get("timeout", self.settings.redfish_timeout),
+                max_retry=self.settings.redfish_max_retry,
+            )
+            redfish_obj.login(auth="session")
+        except InvalidCredentialsError as e:
+            result = False
+            logger.error("invalid redfish credential: %s", str(e))
+        except Exception as e:  # pylint: disable=W0718
+            result = False
+            logger.error("cannot connect to redfish: %s", str(e))
+        else:
+            result = True
+        finally:
+            # Make sure to close connection at the end
+            if redfish_obj:
+                redfish_obj.logout()
+
+        return result
+
+    def get_redfish_conn_params(self, config) -> Dict[str, Any]:
+        """Get redfish connection parameters if redfish is available."""
+        bmc_tools = bmc_hw_verifier()
+        if HWTool.REDFISH not in bmc_tools:
+            logger.warning("Redfish unavailable, disregarding redfish config options...")
+            return {}
+        return {
+            "host": f"https://{get_bmc_address()}",
+            "username": config["redfish-username"],
+            "password": config["redfish-password"],
+            "timeout": config["collect-timeout"],
+        }

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -3,7 +3,7 @@ import logging
 import pytest
 from utils import RESOURCES_DIR, Resource
 
-from config import EXPORTER_COLLECTOR_MAPPING, TPR_RESOURCES, HWTool
+from config import HARDWARE_EXPORTER_COLLECTOR_MAPPING, TPR_RESOURCES, HWTool
 
 log = logging.getLogger(__name__)
 
@@ -91,7 +91,7 @@ def resources() -> list[Resource]:
         Resource(
             resource_name=TPR_RESOURCES.get(HWTool.STORCLI),
             file_name="storcli.deb",
-            collector_name=EXPORTER_COLLECTOR_MAPPING.get(HWTool.STORCLI)[0].replace(
+            collector_name=HARDWARE_EXPORTER_COLLECTOR_MAPPING.get(HWTool.STORCLI)[0].replace(
                 "collector.", ""
             ),
             bin_name=HWTool.STORCLI.value,
@@ -99,7 +99,7 @@ def resources() -> list[Resource]:
         Resource(
             resource_name=TPR_RESOURCES.get(HWTool.PERCCLI),
             file_name="perccli.deb",
-            collector_name=EXPORTER_COLLECTOR_MAPPING.get(HWTool.PERCCLI)[0].replace(
+            collector_name=HARDWARE_EXPORTER_COLLECTOR_MAPPING.get(HWTool.PERCCLI)[0].replace(
                 "collector.", ""
             ),
             bin_name=HWTool.PERCCLI.value,
@@ -107,7 +107,7 @@ def resources() -> list[Resource]:
         Resource(
             resource_name=TPR_RESOURCES.get(HWTool.SAS2IRCU),
             file_name="sas2ircu",
-            collector_name=EXPORTER_COLLECTOR_MAPPING.get(HWTool.SAS2IRCU)[0].replace(
+            collector_name=HARDWARE_EXPORTER_COLLECTOR_MAPPING.get(HWTool.SAS2IRCU)[0].replace(
                 "collector.", ""
             ),
             bin_name=HWTool.SAS2IRCU.value,
@@ -115,7 +115,7 @@ def resources() -> list[Resource]:
         Resource(
             resource_name=TPR_RESOURCES.get(HWTool.SAS3IRCU),
             file_name="sas3ircu",
-            collector_name=EXPORTER_COLLECTOR_MAPPING.get(HWTool.SAS3IRCU)[0].replace(
+            collector_name=HARDWARE_EXPORTER_COLLECTOR_MAPPING.get(HWTool.SAS3IRCU)[0].replace(
                 "collector.", ""
             ),
             bin_name=HWTool.SAS3IRCU.value,

--- a/tests/functional/requirements.txt
+++ b/tests/functional/requirements.txt
@@ -5,3 +5,4 @@ pytest-operator
 # https://github.com/go-macaroon-bakery/py-macaroon-bakery/issues/94
 protobuf<4.0
 tenacity
+pydantic

--- a/tests/functional/test_charm.py
+++ b/tests/functional/test_charm.py
@@ -534,10 +534,10 @@ class TestCharm:
     """Perform basic functional testing of the charm without having the actual hardware."""
 
     async def test_config_changed_port(self, app, unit, ops_test):
-        """Test changing the config option: exporter-port."""
+        """Test changing the config option: hardware-exporter-port."""
         new_port = "10001"
         await asyncio.gather(
-            app.set_config({"exporter-port": new_port}),
+            app.set_config({"hardware-exporter-port": new_port}),
             ops_test.model.wait_for_idle(apps=[APP_NAME]),
         )
 
@@ -547,7 +547,7 @@ class TestCharm:
         config = yaml.safe_load(results.get("stdout").strip())
         assert config["port"] == int(new_port)
 
-        await app.reset_config(["exporter-port"])
+        await app.reset_config(["hardware-exporter-port"])
 
     async def test_config_changed_log_level(self, app, unit, ops_test):
         """Test changing the config option: exporter-log-level."""


### PR DESCRIPTION
Some refactor so that adding a new exporter becomes simpler. After this is merged, a new exporter can be added by implementing:
1.  a new `XxxExporter` class that inherits from `BaseExporter`.
2. Initialize the new exporter in charm init and append it to `self.exporters`. 