### PR TITLE
feat: Manage redfish client timeout with collect-timeout charm config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -19,11 +19,12 @@ options:
       failure of the exporter.
   collect-timeout:
     type: int
-    default: 10
+    default: 15
     description: |
       Timeout for collectors' shell commands in seconds. Changing this will also change
       the scrape_timeout config option for prometheus for the cos-agent relation with
       grafana-agent.
+      This value is also used for the redfish client's timeout parameter.
       The value of this timeout should not be greater than prometheus scrape_interval (which
       is 60 seconds by default), as it greater would cause the scrape_timeout to be
       greater than scrape_interval.
@@ -37,8 +38,3 @@ options:
     default: ""
     description: |
       BMC password to be used by the redfish collector.
-  redfish-client-timeout:
-    type: int
-    default: 15
-    description: |
-      Timeout for redfish_client in seconds.

--- a/config.yaml
+++ b/config.yaml
@@ -37,3 +37,8 @@ options:
     default: ""
     description: |
       BMC password to be used by the redfish collector.
+  redfish-client-timeout:
+    type: int
+    default: 15
+    description: |
+      Timeout for redfish_client in seconds.

--- a/src/charm.py
+++ b/src/charm.py
@@ -227,6 +227,7 @@ class HardwareObserverCharm(ops.CharmBase):
             "host": f"https://{get_bmc_address()}",
             "username": self.model.config.get("redfish-username", ""),
             "password": self.model.config.get("redfish-password", ""),
+            "timeout": self.model.config.get("redfish-client-timeout"),
         }
 
     def validate_exporter_configs(self) -> Tuple[bool, str]:

--- a/src/charm.py
+++ b/src/charm.py
@@ -227,7 +227,7 @@ class HardwareObserverCharm(ops.CharmBase):
             "host": f"https://{get_bmc_address()}",
             "username": self.model.config.get("redfish-username", ""),
             "password": self.model.config.get("redfish-password", ""),
-            "timeout": self.model.config.get("redfish-client-timeout"),
+            "timeout": self.model.config.get("collect-timeout"),
         }
 
     def validate_exporter_configs(self) -> Tuple[bool, str]:
@@ -288,7 +288,7 @@ class HardwareObserverCharm(ops.CharmBase):
                 base_url=redfish_conn_params.get("host", ""),
                 username=redfish_conn_params.get("username", ""),
                 password=redfish_conn_params.get("password", ""),
-                timeout=REDFISH_TIMEOUT,
+                timeout=redfish_conn_params.get("timeout", REDFISH_TIMEOUT),
                 max_retry=REDFISH_MAX_RETRY,
             )
             redfish_obj.login(auth="session")

--- a/src/service.py
+++ b/src/service.py
@@ -104,7 +104,7 @@ class ExporterTemplate:
             REDFISH_HOST=redfish_conn_params.get("host", ""),
             REDFISH_USERNAME=redfish_conn_params.get("username", ""),
             REDFISH_PASSWORD=redfish_conn_params.get("password", ""),
-            REDFISH_CLIENT_TIMEOUT=redfish_conn_params.get("timeout"),
+            REDFISH_CLIENT_TIMEOUT=redfish_conn_params.get("timeout", ""),
         )
         return self._install(EXPORTER_CONFIG_PATH, content)
 

--- a/src/service.py
+++ b/src/service.py
@@ -104,6 +104,7 @@ class ExporterTemplate:
             REDFISH_HOST=redfish_conn_params.get("host", ""),
             REDFISH_USERNAME=redfish_conn_params.get("username", ""),
             REDFISH_PASSWORD=redfish_conn_params.get("password", ""),
+            REDFISH_CLIENT_TIMEOUT=redfish_conn_params.get("timeout"),
         )
         return self._install(EXPORTER_CONFIG_PATH, content)
 

--- a/templates/hardware-exporter-config.yaml.j2
+++ b/templates/hardware-exporter-config.yaml.j2
@@ -12,4 +12,5 @@ enable_collectors:
 redfish_host: "{{ REDFISH_HOST }}"
 redfish_username: "{{ REDFISH_USERNAME }}"
 redfish_password: "{{ REDFISH_PASSWORD }}"
+redfish_client_timeout: "{{ REDFISH_CLIENT_TIMEOUT }}"
 {% endif %}

--- a/tests/unit/test_exporter.py
+++ b/tests/unit/test_exporter.py
@@ -359,6 +359,7 @@ class TestExporterTemplate(unittest.TestCase):
                     REDFISH_HOST="",
                     REDFISH_PASSWORD="",
                     REDFISH_USERNAME="",
+                    REDFISH_CLIENT_TIMEOUT="",
                 ),
             )
 
@@ -376,6 +377,7 @@ class TestExporterTemplate(unittest.TestCase):
                     "host": "127.0.0.1",
                     "username": "default_user",
                     "password": "default_pwd",
+                    "timeout": 20,
                 },
             )
             mock_install.assert_called_with(
@@ -389,5 +391,6 @@ class TestExporterTemplate(unittest.TestCase):
                     REDFISH_HOST="127.0.0.1",
                     REDFISH_PASSWORD="default_pwd",
                     REDFISH_USERNAME="default_user",
+                    REDFISH_CLIENT_TIMEOUT="20",
                 ),
             )

--- a/tests/unit/test_exporter.py
+++ b/tests/unit/test_exporter.py
@@ -359,7 +359,7 @@ class TestExporterTemplate(unittest.TestCase):
                     REDFISH_HOST="",
                     REDFISH_PASSWORD="",
                     REDFISH_USERNAME="",
-                    REDFISH_CLIENT_TIMEOUT="",
+                    REDFISH_CLIENT_TIMEOUT=10,
                 ),
             )
 
@@ -377,7 +377,7 @@ class TestExporterTemplate(unittest.TestCase):
                     "host": "127.0.0.1",
                     "username": "default_user",
                     "password": "default_pwd",
-                    "timeout": 20,
+                    "timeout": 10,
                 },
             )
             mock_install.assert_called_with(
@@ -391,6 +391,6 @@ class TestExporterTemplate(unittest.TestCase):
                     REDFISH_HOST="127.0.0.1",
                     REDFISH_PASSWORD="default_pwd",
                     REDFISH_USERNAME="default_user",
-                    REDFISH_CLIENT_TIMEOUT="20",
+                    REDFISH_CLIENT_TIMEOUT="10",
                 ),
             )


### PR DESCRIPTION
This change allows the user to manage the redfish client timeout using the existing `collect-timeout` charm config. When hardware exporter is installed, this configured value will be used for redfish (also refer [hardware-exporter config.py](https://github.com/canonical/prometheus-hardware-exporter/blob/main/prometheus_hardware_exporter/config.py#L36) for config definition and [main.py](https://github.com/canonical/prometheus-hardware-exporter/blob/main/prometheus_hardware_exporter/__main__.py#L186) where config is loaded from file).

Fixes #170 