### PR TITLE
feat: redetect-hardwares juju action

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -28,10 +28,17 @@ bases:
 actions:
   detect-hardwares:
     description: >
-      Redetect the hardwares and reinitialize the charm.
-      The exporter service(s) will be reconfigured and restarted.
+      Re-detect the hardwares on the device and provide an option to
+      reinitialize the charm.
+
+      Default will only show the current hardward tool list and compare with new
+      detection.
+      The exporter service(s) will be reconfigured and restarted if option
+      `--apply` is provided.
     params:
-      dry-run:
+      apply:
         type: boolean
-        description: Only run detection without restart the exporter service.
+        description: |
+          Run detection and use it as the enablelist to restart the exporter
+          service(s).
         default: false

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -26,9 +26,9 @@ bases:
           - amd64
 
 actions:
-  detect-hardwares:
+  detect-hardware:
     description: >
-      Re-detect the hardwares on the device and provide an option to
+      Re-detect the hardware on the device and provide an option to
       reinitialize the charm.
 
       Default will only show the current hardward tool list and compare with new

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -24,3 +24,14 @@ bases:
         channel: "20.04"
         architectures:
           - amd64
+
+actions:
+  detect-hardwares:
+    description: >
+      Redetect the hardwares and reinitialize the charm.
+      The exporter service(s) will be reconfigured and restarted.
+    params:
+      dry-run:
+        type: boolean
+        description: Only run detection without restart the exporter service.
+        default: false

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -34,7 +34,7 @@ actions:
       Default will only show the current hardward tool list and compare with new
       detection.
       The exporter service(s) will be reconfigured and restarted if option
-      `--apply` is provided.
+      `apply` is provided.
     params:
       apply:
         type: boolean

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -26,9 +26,9 @@ bases:
           - amd64
 
 actions:
-  detect-hardware:
+  redetect-hardware:
     description: >
-      Re-detect the hardware on the device and provide an option to
+      Redetect the hardware on the device and provide an option to
       reinitialize the charm.
 
       Default will only show the current hardward tool list and compare with new

--- a/src/charm.py
+++ b/src/charm.py
@@ -100,7 +100,7 @@ class HardwareObserverCharm(ops.CharmBase):
         detected_hw_tool_str_list.sort()
 
         hw_change_detected = False
-        if current_hw_tools_str_list == detected_hw_tool_str_list:
+        if current_hw_tools_str_list != detected_hw_tool_str_list:
             hw_change_detected = True
 
         result = {
@@ -109,10 +109,10 @@ class HardwareObserverCharm(ops.CharmBase):
             "update-hardware-tools": False,
         }
         # Show compare lists if not hw_change_detected
-        if not hw_change_detected:
+        if hw_change_detected:
             result["current-hardware-tools"] = ",".join(current_hw_tools_str_list)
 
-        if event.params["apply"] and not hw_change_detected:
+        if event.params["apply"] and hw_change_detected:
             # Reset the value in local Store
             self._stored.enabled_hw_tool_list_values = detected_hw_tool_str_list
             event.log(f"Run install hook with enable tools: {','.join(detected_hw_tool_str_list)}")

--- a/src/charm.py
+++ b/src/charm.py
@@ -66,7 +66,7 @@ class HardwareObserverCharm(ops.CharmBase):
         self.framework.observe(
             self.on.cos_agent_relation_departed, self._on_cos_agent_relation_departed
         )
-        self.framework.observe(self.on.detect_hardwares_action, self._on_detect_hardwares)
+        self.framework.observe(self.on.detect_hardware_action, self._on_detect_hardware)
 
         self._stored.set_default(
             exporter_installed=False,
@@ -89,7 +89,7 @@ class HardwareObserverCharm(ops.CharmBase):
         """Get HWTool objects from hw tool values."""
         return [HWTool(value) for value in hw_tool_values]
 
-    def _on_detect_hardwares(self, event: ops.ActionEvent) -> None:
+    def _on_detect_hardware(self, event: ops.ActionEvent) -> None:
         """Detect hardware tool list and option to rerun the install hook."""
         current_hw_tools_value_list = self.get_enabled_hw_tool_list_values()
         current_hw_tools_str_list = [str(tool) for tool in current_hw_tools_value_list]

--- a/src/charm.py
+++ b/src/charm.py
@@ -105,12 +105,12 @@ class HardwareObserverCharm(ops.CharmBase):
 
         result = {
             "hardware-change-detected": hw_change_detected,
-            "detected-hardware-tools": ",".join(detected_hw_tool_str_list),
+            "current-hardware-tools": ",".join(current_hw_tools_str_list),
             "update-hardware-tools": False,
         }
-        # Show compare lists if not hw_change_detected
+        # Show compare lists if hw_change_detected
         if hw_change_detected:
-            result["current-hardware-tools"] = ",".join(current_hw_tools_str_list)
+            result["detected-hardware-tools"] = ",".join(detected_hw_tool_str_list)
 
         if event.params["apply"] and hw_change_detected:
             # Reset the value in local Store

--- a/src/hardware.py
+++ b/src/hardware.py
@@ -97,8 +97,8 @@ def hwinfo(*args: str) -> t.Dict[str, str]:
     if "start debug info" in output.splitlines()[0]:
         output = output.split("=========== end debug info ============")[1]
 
-    hardwares: t.Dict[str, str] = {}
+    hardware: t.Dict[str, str] = {}
     for item in output.split("\n\n"):
         key = item.splitlines()[0].strip()
-        hardwares[key] = item
-    return hardwares
+        hardware[key] = item
+    return hardware

--- a/src/hw_tools.py
+++ b/src/hw_tools.py
@@ -1,6 +1,6 @@
 """Helper for hardware tools.
 
-Define strategy for install, remove and verifier for different hardwares.
+Define strategy for install, remove and verifier for different hardware.
 """
 
 import logging

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -485,7 +485,7 @@ class TestCharm(unittest.TestCase):
                 ops.testing.ActionOutput(
                     results={
                         "hardware-change-detected": False,
-                        "detected-hardware-tools": "ipmi_dcmi,ipmi_sel,ipmi_sensor,redfish",
+                        "current-hardware-tools": "ipmi_dcmi,ipmi_sel,ipmi_sensor,redfish",
                         "update-hardware-tools": False,
                     },
                     logs=[],
@@ -526,7 +526,7 @@ class TestCharm(unittest.TestCase):
                 ops.testing.ActionOutput(
                     results={
                         "hardware-change-detected": False,
-                        "detected-hardware-tools": "perccli,storcli",
+                        "current-hardware-tools": "perccli,storcli",
                         "update-hardware-tools": False,
                     },
                     logs=[],
@@ -555,13 +555,15 @@ class TestCharm(unittest.TestCase):
 
         output = self.harness.run_action("redetect-hardware", {"apply": apply})
         self.assertEqual(output, expect_output)
+
         if not current_hw_tools == detected_hw_tools:
             if apply:
+                detected_hw_tools.sort()
                 self.assertEqual(
                     self.harness.charm.get_hw_tools_from_values(
                         self.harness.charm._stored.enabled_hw_tool_list_values
                     ),
-                    expect_output.results["detected-hardware-tools"].split(","),
+                    detected_hw_tools,
                 )
                 self.harness.charm._on_install_or_upgrade.assert_called()
             else:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -537,7 +537,7 @@ class TestCharm(unittest.TestCase):
     @mock.patch(
         "charm.get_hw_tool_enable_list",
     )
-    def test_detect_hardwares_action(
+    def test_detect_hardware_action(
         self,
         apply,
         current_hw_tools,
@@ -545,7 +545,7 @@ class TestCharm(unittest.TestCase):
         expect_output,
         mock_get_hw_tool_enable_list,
     ) -> None:
-        """Test action detect-hardwares."""
+        """Test action detect-hardware."""
         mock_get_hw_tool_enable_list.return_value = detected_hw_tools
         self.harness.begin()
         self.harness.charm._on_install_or_upgrade = mock.MagicMock()
@@ -553,7 +553,7 @@ class TestCharm(unittest.TestCase):
             tool.value for tool in current_hw_tools
         ]
 
-        output = self.harness.run_action("detect-hardwares", {"apply": apply})
+        output = self.harness.run_action("detect-hardware", {"apply": apply})
         print(output)
         print(expect_output)
         self.assertEqual(output, expect_output)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -484,7 +484,7 @@ class TestCharm(unittest.TestCase):
                 [HWTool.IPMI_SENSOR, HWTool.IPMI_SEL, HWTool.IPMI_DCMI, HWTool.REDFISH],
                 ops.testing.ActionOutput(
                     results={
-                        "hardware-change-detected": True,
+                        "hardware-change-detected": False,
                         "detected-hardware-tools": "ipmi_dcmi,ipmi_sel,ipmi_sensor,redfish",
                         "update-hardware-tools": False,
                     },
@@ -497,7 +497,7 @@ class TestCharm(unittest.TestCase):
                 [HWTool.IPMI_SENSOR, HWTool.IPMI_SEL, HWTool.IPMI_DCMI],
                 ops.testing.ActionOutput(
                     results={
-                        "hardware-change-detected": False,
+                        "hardware-change-detected": True,
                         "detected-hardware-tools": "ipmi_dcmi,ipmi_sel,ipmi_sensor",
                         "current-hardware-tools": "ipmi_dcmi,ipmi_sel,ipmi_sensor,redfish",
                         "update-hardware-tools": False,
@@ -511,7 +511,7 @@ class TestCharm(unittest.TestCase):
                 [HWTool.IPMI_SENSOR, HWTool.IPMI_SEL, HWTool.IPMI_DCMI],
                 ops.testing.ActionOutput(
                     results={
-                        "hardware-change-detected": False,
+                        "hardware-change-detected": True,
                         "detected-hardware-tools": "ipmi_dcmi,ipmi_sel,ipmi_sensor",
                         "current-hardware-tools": "ipmi_dcmi,ipmi_sel,ipmi_sensor,redfish",
                         "update-hardware-tools": True,
@@ -525,7 +525,7 @@ class TestCharm(unittest.TestCase):
                 [HWTool.PERCCLI, HWTool.STORCLI],
                 ops.testing.ActionOutput(
                     results={
-                        "hardware-change-detected": True,
+                        "hardware-change-detected": False,
                         "detected-hardware-tools": "perccli,storcli",
                         "update-hardware-tools": False,
                     },

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -484,9 +484,9 @@ class TestCharm(unittest.TestCase):
                 [HWTool.IPMI_SENSOR, HWTool.IPMI_SEL, HWTool.IPMI_DCMI, HWTool.REDFISH],
                 ops.testing.ActionOutput(
                     results={
-                        "consistent": True,
-                        "detected-hw-tools": "ipmi_dcmi,ipmi_sel,ipmi_sensor,redfish",
-                        "apply": False,
+                        "hardware-change-detected": True,
+                        "detected-hardware-tools": "ipmi_dcmi,ipmi_sel,ipmi_sensor,redfish",
+                        "update-hardware-tools": False,
                     },
                     logs=[],
                 ),
@@ -497,10 +497,10 @@ class TestCharm(unittest.TestCase):
                 [HWTool.IPMI_SENSOR, HWTool.IPMI_SEL, HWTool.IPMI_DCMI],
                 ops.testing.ActionOutput(
                     results={
-                        "consistent": False,
-                        "detected-hw-tools": "ipmi_dcmi,ipmi_sel,ipmi_sensor",
-                        "current-hw-tools": "ipmi_dcmi,ipmi_sel,ipmi_sensor,redfish",
-                        "apply": False,
+                        "hardware-change-detected": False,
+                        "detected-hardware-tools": "ipmi_dcmi,ipmi_sel,ipmi_sensor",
+                        "current-hardware-tools": "ipmi_dcmi,ipmi_sel,ipmi_sensor,redfish",
+                        "update-hardware-tools": False,
                     },
                     logs=[],
                 ),
@@ -511,10 +511,10 @@ class TestCharm(unittest.TestCase):
                 [HWTool.IPMI_SENSOR, HWTool.IPMI_SEL, HWTool.IPMI_DCMI],
                 ops.testing.ActionOutput(
                     results={
-                        "consistent": False,
-                        "detected-hw-tools": "ipmi_dcmi,ipmi_sel,ipmi_sensor",
-                        "current-hw-tools": "ipmi_dcmi,ipmi_sel,ipmi_sensor,redfish",
-                        "apply": True,
+                        "hardware-change-detected": False,
+                        "detected-hardware-tools": "ipmi_dcmi,ipmi_sel,ipmi_sensor",
+                        "current-hardware-tools": "ipmi_dcmi,ipmi_sel,ipmi_sensor,redfish",
+                        "update-hardware-tools": True,
                     },
                     logs=["Run install hook with enable tools: ipmi_dcmi,ipmi_sel,ipmi_sensor"],
                 ),
@@ -525,9 +525,9 @@ class TestCharm(unittest.TestCase):
                 [HWTool.PERCCLI, HWTool.STORCLI],
                 ops.testing.ActionOutput(
                     results={
-                        "consistent": True,
-                        "detected-hw-tools": "perccli,storcli",
-                        "apply": False,
+                        "hardware-change-detected": True,
+                        "detected-hardware-tools": "perccli,storcli",
+                        "update-hardware-tools": False,
                     },
                     logs=[],
                 ),
@@ -553,9 +553,7 @@ class TestCharm(unittest.TestCase):
             tool.value for tool in current_hw_tools
         ]
 
-        output = self.harness.run_action("detect-hardware", {"apply": apply})
-        print(output)
-        print(expect_output)
+        output = self.harness.run_action("redetect-hardware", {"apply": apply})
         self.assertEqual(output, expect_output)
         if not current_hw_tools == detected_hw_tools:
             if apply:
@@ -563,7 +561,7 @@ class TestCharm(unittest.TestCase):
                     self.harness.charm.get_hw_tools_from_values(
                         self.harness.charm._stored.enabled_hw_tool_list_values
                     ),
-                    expect_output.results["detected-hw-tools"].split(","),
+                    expect_output.results["detected-hardware-tools"].split(","),
                 )
                 self.harness.charm._on_install_or_upgrade.assert_called()
             else:


### PR DESCRIPTION
Redetect the hardwares and reinitialize the charm. The exporter service(s) will be reconfigured and restarted.