### PR TITLE
refactor: remove multiple relation check in charm code.

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -28,7 +28,7 @@ resources:
       (Optional) StorCLI deb file published by Broadcom for their RAID devices.
       Download v7.26 from: https://docs.broadcom.com/docs/1232743291.
       The download will start automatically upon accepting the license agreement.
-      Unzip the downloaded file and attach the relevant deb package. 
+      Unzip the downloaded file and attach the relevant deb package.
       Eg: ./Unified_storcli_all_os/Ubuntu/storcli_007.2612.0000.0000_all.deb
     filename: storcli.deb
 
@@ -38,7 +38,7 @@ resources:
       (Optional) PERCCLI deb file published by Dell for their RAID devices.
       Download v7.23 from https://www.dell.com/support/home/en-us/drivers/driversdetails?driverid=tdghn.
       Scroll down to "Available Formats" and download the PERCCLI_XXX_Linux.tar.gz file.
-      Extract the downloaded file and attach the relevant deb package. 
+      Extract the downloaded file and attach the relevant deb package.
       Eg: ./PERCCLI_7.2313.0_A14_Linux/perccli_007.2313.0000.0000_all.deb
     filename: perccli.deb
 
@@ -48,7 +48,7 @@ resources:
       (Optional) SASIRCU binary file published by Broadcom.
       Download vP20 from https://docs.broadcom.com/docs/12351735.
       The download will start automatically upon accepting the license agreement.
-      Unzip the downloaded file and attach the relevant binary. 
+      Unzip the downloaded file and attach the relevant binary.
       Eg: ./SAS2IRCU_P20/sas2ircu_linux_x86_rel/sas2ircu
     filename: sas2ircu
 
@@ -58,13 +58,14 @@ resources:
       (Optional) SASIRCU binary file published by Broadcom.
       Download vP16 from https://docs.broadcom.com/docs/SAS3IRCU_P16.zip.
       The download will start automatically upon accepting the license agreement.
-      Unzip the downloaded file and attach the relevant binary. 
+      Unzip the downloaded file and attach the relevant binary.
       Eg: ./SAS3IRCU_P16/sas3ircu_rel/sas3ircu_linux_x86_rel/sas3ircu
     filename: sas3ircu
 
 provides:
   cos-agent:
     interface: cos_agent
+    limit: 1
 
 requires:
   general-info:

--- a/src/charm.py
+++ b/src/charm.py
@@ -182,10 +182,6 @@ class HardwareObserverCharm(ops.CharmBase):
             self.model.unit.status = BlockedStatus("Missing relation: [cos-agent]")
             return
 
-        if self.too_many_cos_agent_relations:
-            self.model.unit.status = BlockedStatus("Cannot relate to more than one grafana-agent")
-            return
-
         config_valid, config_valid_message = self.validate_exporter_configs()
         if not config_valid:
             self.model.unit.status = BlockedStatus(config_valid_message)
@@ -322,12 +318,7 @@ class HardwareObserverCharm(ops.CharmBase):
     @property
     def exporter_enabled(self) -> bool:
         """Return True if cos-agent relation is present."""
-        return self.num_cos_agent_relations != 0
-
-    @property
-    def too_many_cos_agent_relations(self) -> bool:
-        """Return True if there're more than one cos-agent relation."""
-        return self.num_cos_agent_relations > 1
+        return self.num_cos_agent_relations == 1
 
     @property
     def redfish_conn_params_valid(self) -> Optional[bool]:

--- a/tests/unit/test_exporter.py
+++ b/tests/unit/test_exporter.py
@@ -249,23 +249,6 @@ class TestExporter(unittest.TestCase):
         )
 
     @mock.patch.object(pathlib.Path, "exists", return_value=True)
-    def test_too_many_relations(self, mock_service_installed):
-        """Test there too many relations."""
-        rid_1 = self.harness.add_relation(EXPORTER_RELATION_NAME, "grafana-agent")
-        rid_2 = self.harness.add_relation(EXPORTER_RELATION_NAME, "grafana-agent")
-        self.harness.begin()
-        with mock.patch("builtins.open", new_callable=mock.mock_open) as _:
-            self.harness.charm.on.install.emit()
-            self.harness.add_relation_unit(rid_1, "grafana-agent/0")
-            self.harness.add_relation_unit(rid_2, "grafana-agent/1")
-        self.mock_systemd.service_failed.return_value = False
-        self.harness.charm.on.update_status.emit()
-        self.assertEqual(
-            self.harness.charm.unit.status,
-            BlockedStatus("Cannot relate to more than one grafana-agent"),
-        )
-
-    @mock.patch.object(pathlib.Path, "exists", return_value=True)
     def test_config_changed_log_level_okay(self, mock_service_installed):
         """Test on_config_change function when exporter-log-level is changed."""
         rid = self.harness.add_relation(EXPORTER_RELATION_NAME, "grafana-agent")

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,6 @@ passenv =
   OS_*
 
 [testenv:dev-environment]
-envdir = {toxinidir}/.venv
 deps =
   pre-commit
   {[testenv:lint]deps}
@@ -35,7 +34,6 @@ deps =
   {[testenv:func]deps}
 
 [testenv:pre-commit]
-envdir = {[testenv:dev-environment]envdir}
 deps = {[testenv:dev-environment]deps}  # ensure that dev-environment is installed
 commands = pre-commit run --all-files
 
@@ -61,7 +59,6 @@ deps =
     {[testenv:func]deps}
 
 [testenv:reformat]
-envdir = {toxworkdir}/lint
 commands =
     black .
     isort .


### PR DESCRIPTION
The `metadata.yaml` support `limit` for interface, this can limits how many relation the interface can be connected to, and we can handle the relation checks in juju level.

Also removed the incorrect usage of `envdir` in `tox.ini` this is no longer working in `tox >= 4`.

Old behavior:

```shell
$ juju status
hardware-observer/1*  active    blocked            10.42.75.15            Cannot relate to more than one grafana-agent
```

New behavior:

```shell
$ juju relate g2  hardware-observer
ERROR cannot add relation "g2:cos-agent hardware-observer:cos-agent": establishing a new relation for hardware-observer:cos-agent would exceed its maximum relation limit of 1 (quota limit exceeded)
```

Closes: #144 