### PR TITLE
Dev/handle hw list in stored

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -39,6 +39,6 @@ actions:
       apply:
         type: boolean
         description: |
-          Run detection and use it as the enablelist to restart the exporter
-          service(s).
+          Use the re-detected list of hardware tools as the new enable-list to reconfigure
+          and restart the exporter.
         default: false

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -24,3 +24,21 @@ bases:
         channel: "20.04"
         architectures:
           - amd64
+
+actions:
+  redetect-hardware:
+    description: >
+      Redetect the hardware on the device and provide an option to
+      reinitialize the charm.
+
+      Default will only show the current hardward tool list and compare with new
+      detection.
+      The exporter service(s) will be reconfigured and restarted if option
+      `apply` is provided.
+    params:
+      apply:
+        type: boolean
+        description: |
+          Run detection and use it as the enablelist to restart the exporter
+          service(s).
+        default: false

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -31,7 +31,7 @@ actions:
       Redetect the hardware on the device and provide an option to
       reinitialize the charm.
 
-      Default will only show the current hardward tool list and compare with new
+      By default, this will only show the current hardware tool list and compare with new
       detection.
       The exporter service(s) will be reconfigured and restarted if option
       `apply` is provided.

--- a/src/charm.py
+++ b/src/charm.py
@@ -6,7 +6,7 @@
 
 import logging
 from time import sleep
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import ops
 from charms.grafana_agent.v0.cos_agent import COSAgentProvider
@@ -24,7 +24,7 @@ from config import (
     HWTool,
 )
 from hardware import get_bmc_address
-from hw_tools import HWToolHelper, bmc_hw_verifier
+from hw_tools import HWToolHelper, get_hw_tool_enable_list
 from service import Exporter, ExporterError
 
 logger = logging.getLogger(__name__)
@@ -70,14 +70,34 @@ class HardwareObserverCharm(ops.CharmBase):
         self._stored.set_default(
             exporter_installed=False,
             resource_installed=False,
+            # Storing only the values from `HWTool` because entire HWTool
+            # cannot be stored in _stored. Only simple types can be stored.
+            enabled_hw_tool_list_values=[],
         )
         self.num_cos_agent_relations = self.get_num_cos_agent_relations("cos-agent")
 
-    def _on_install_or_upgrade(self, event: ops.InstallEvent) -> None:
+    def get_enabled_hw_tool_list_values(self) -> List[str]:
+        """Get hw tool list from stored or from machine if not in stored."""
+        if not self._stored.enabled_hw_tool_list_values:  # type: ignore[truthy-function]
+            self._stored.enabled_hw_tool_list_values = [  # type: ignore[unreachable]
+                tool.value for tool in get_hw_tool_enable_list()
+            ]
+        return self._stored.enabled_hw_tool_list_values  # type: ignore[return-value]
+
+    def get_hw_tools_from_values(self, hw_tool_values: List[str]) -> List[HWTool]:
+        """Get HWTool objects from hw tool values."""
+        return [HWTool(value) for value in hw_tool_values]
+
+    def _on_install_or_upgrade(self, event: ops.HookEvent) -> None:
         """Install or upgrade charm."""
         self.model.unit.status = MaintenanceStatus("Installing resources...")
 
-        resource_installed, msg = self.hw_tool_helper.install(self.model.resources)
+        enabled_hw_tool_list_values = self.get_enabled_hw_tool_list_values()
+        enabled_hw_tool_list = self.get_hw_tools_from_values(enabled_hw_tool_list_values)
+
+        resource_installed, msg = self.hw_tool_helper.install(
+            self.model.resources, enabled_hw_tool_list
+        )
         self._stored.resource_installed = resource_installed
 
         if not resource_installed:
@@ -90,8 +110,9 @@ class HardwareObserverCharm(ops.CharmBase):
         success = self.exporter.install(
             int(self.model.config["exporter-port"]),
             self.model.config["exporter-log-level"],
-            self.get_redfish_conn_params(),
+            self.get_redfish_conn_params(enabled_hw_tool_list),
             int(self.model.config["collect-timeout"]),
+            enabled_hw_tool_list,
         )
         self._stored.exporter_installed = success
         if not success:
@@ -105,7 +126,10 @@ class HardwareObserverCharm(ops.CharmBase):
         """Remove everything when charm is being removed."""
         logger.info("Start to remove.")
         # Remove binary tool
-        self.hw_tool_helper.remove(self.model.resources)
+        self.hw_tool_helper.remove(
+            self.model.resources,
+            self.get_hw_tools_from_values(self.get_enabled_hw_tool_list_values()),
+        )
         self._stored.resource_installed = False
         success = self.exporter.uninstall()
         if not success:
@@ -135,7 +159,9 @@ class HardwareObserverCharm(ops.CharmBase):
             self.model.unit.status = BlockedStatus(config_valid_message)
             return
 
-        hw_tool_ok, error_msg = self.hw_tool_helper.check_installed()
+        hw_tool_ok, error_msg = self.hw_tool_helper.check_installed(
+            self.get_hw_tools_from_values(self.get_enabled_hw_tool_list_values())
+        )
         if not hw_tool_ok:
             self.model.unit.status = BlockedStatus(error_msg)
             return
@@ -182,8 +208,11 @@ class HardwareObserverCharm(ops.CharmBase):
             success = self.exporter.template.render_config(
                 port=int(self.model.config["exporter-port"]),
                 level=self.model.config["exporter-log-level"],
-                redfish_conn_params=self.get_redfish_conn_params(),
+                redfish_conn_params=self.get_redfish_conn_params(
+                    self.get_hw_tools_from_values(self.get_enabled_hw_tool_list_values())
+                ),
                 collect_timeout=int(self.model.config["collect-timeout"]),
+                hw_tools=self.get_hw_tools_from_values(self.get_enabled_hw_tool_list_values()),
             )
             if not success:
                 message = "Failed to configure exporter, please check if the server is healthy."
@@ -217,10 +246,9 @@ class HardwareObserverCharm(ops.CharmBase):
             logger.info("Stop and disable exporter service")
         self._on_update_status(event)
 
-    def get_redfish_conn_params(self) -> Dict[str, Any]:
+    def get_redfish_conn_params(self, enabled_hw_tool_list: List[HWTool]) -> Dict[str, Any]:
         """Get redfish connection parameters if redfish is available."""
-        bmc_tools = bmc_hw_verifier()
-        if HWTool.REDFISH not in bmc_tools:
+        if HWTool.REDFISH not in enabled_hw_tool_list:
             logger.warning("Redfish unavailable, disregarding redfish config options...")
             return {}
         return {
@@ -277,7 +305,9 @@ class HardwareObserverCharm(ops.CharmBase):
         connection parameters are valid, it returns True; if not valid, it
         returns False.
         """
-        redfish_conn_params = self.get_redfish_conn_params()
+        redfish_conn_params = self.get_redfish_conn_params(
+            self.get_hw_tools_from_values(self.get_enabled_hw_tool_list_values())
+        )
         if not redfish_conn_params:
             return None
 

--- a/src/hardware.py
+++ b/src/hardware.py
@@ -97,8 +97,8 @@ def hwinfo(*args: str) -> t.Dict[str, str]:
     if "start debug info" in output.splitlines()[0]:
         output = output.split("=========== end debug info ============")[1]
 
-    hardwares: t.Dict[str, str] = {}
+    hardware: t.Dict[str, str] = {}
     for item in output.split("\n\n"):
         key = item.splitlines()[0].strip()
-        hardwares[key] = item
-    return hardwares
+        hardware[key] = item
+    return hardware

--- a/src/hw_tools.py
+++ b/src/hw_tools.py
@@ -1,6 +1,6 @@
 """Helper for hardware tools.
 
-Define strategy for install, remove and verifier for different hardwares.
+Define strategy for install, remove and verifier for different hardware.
 """
 
 import logging

--- a/src/service.py
+++ b/src/service.py
@@ -3,7 +3,7 @@
 from functools import wraps
 from logging import getLogger
 from pathlib import Path
-from typing import Any, Callable, Dict, Tuple
+from typing import Any, Callable, Dict, List, Tuple
 
 from charms.operator_libs_linux.v1 import systemd
 from jinja2 import Environment, FileSystemLoader
@@ -15,8 +15,8 @@ from config import (
     EXPORTER_NAME,
     EXPORTER_SERVICE_PATH,
     EXPORTER_SERVICE_TEMPLATE,
+    HWTool,
 )
-from hw_tools import get_hw_tool_white_list
 
 logger = getLogger(__name__)
 
@@ -85,11 +85,16 @@ class ExporterTemplate:
             logger.info("Removing file '%s' - Done.", path)
         return success
 
+    # pylint: disable=too-many-arguments
     def render_config(
-        self, port: int, level: str, collect_timeout: int, redfish_conn_params: dict
+        self,
+        port: int,
+        level: str,
+        collect_timeout: int,
+        redfish_conn_params: dict,
+        hw_tools: List[HWTool],
     ) -> bool:
         """Render and install exporter config file."""
-        hw_tools = get_hw_tool_white_list()
         collectors = []
         for tool in hw_tools:
             collector = EXPORTER_COLLECTOR_MAPPING.get(tool)
@@ -129,8 +134,14 @@ class Exporter:
         self.charm_dir = charm_dir
         self.template = ExporterTemplate(charm_dir)
 
+    # pylint: disable=too-many-arguments
     def install(
-        self, port: int, level: str, redfish_conn_params: dict, collect_timeout: int
+        self,
+        port: int,
+        level: str,
+        redfish_conn_params: dict,
+        collect_timeout: int,
+        hw_tool_enable_list: List,
     ) -> bool:
         """Install the exporter."""
         logger.info("Installing %s.", EXPORTER_NAME)
@@ -139,6 +150,7 @@ class Exporter:
             level=level,
             redfish_conn_params=redfish_conn_params,
             collect_timeout=collect_timeout,
+            hw_tools=hw_tool_enable_list,
         )
         success = self.template.render_service(str(self.charm_dir), str(EXPORTER_CONFIG_PATH))
         if not success:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -28,15 +28,15 @@ class TestCharm(unittest.TestCase):
         self.mock_get_bmc_address.return_value = "127.0.0.1"
         self.addCleanup(get_bmc_address_patcher.stop)
 
-        bmc_hw_verifier_patcher = mock.patch.object(charm, "bmc_hw_verifier")
-        self.mock_bmc_hw_verifier = bmc_hw_verifier_patcher.start()
-        self.mock_bmc_hw_verifier.return_value = [
+        get_hw_tool_enable_list_patcher = mock.patch.object(charm, "get_hw_tool_enable_list")
+        self.mock_get_hw_tool_enable_list = get_hw_tool_enable_list_patcher.start()
+        self.mock_get_hw_tool_enable_list.return_value = [
             HWTool.IPMI_SENSOR,
             HWTool.IPMI_SEL,
             HWTool.IPMI_DCMI,
             HWTool.REDFISH,
         ]
-        self.addCleanup(bmc_hw_verifier_patcher.stop)
+        self.addCleanup(get_hw_tool_enable_list_patcher.stop)
 
         redfish_client_patcher = mock.patch("charm.redfish_client")
         redfish_client_patcher.start()
@@ -71,13 +71,15 @@ class TestCharm(unittest.TestCase):
         mock_hw_tool_helper.return_value.install.return_value = (True, "")
         mock_exporter.return_value.install.return_value = True
         self.harness.begin()
+        self.harness.charm._stored.enabled_hw_tool_list_values = []
         self.harness.charm.on.install.emit()
 
         self.assertTrue(self.harness.charm._stored.resource_installed)
 
         self.harness.charm.exporter.install.assert_called_once()
         self.harness.charm.hw_tool_helper.install.assert_called_with(
-            self.harness.charm.model.resources
+            self.harness.charm.model.resources,
+            self.harness.charm._stored.enabled_hw_tool_list_values,
         )
 
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())
@@ -87,13 +89,15 @@ class TestCharm(unittest.TestCase):
         mock_hw_tool_helper.return_value.install.return_value = (True, "")
         mock_exporter.return_value.install.return_value = True
         self.harness.begin()
+        self.harness.charm._stored.enabled_hw_tool_list_values = []
         self.harness.charm.on.install.emit()
 
         self.assertTrue(self.harness.charm._stored.resource_installed)
 
         self.harness.charm.exporter.install.assert_called_once()
         self.harness.charm.hw_tool_helper.install.assert_called_with(
-            self.harness.charm.model.resources
+            self.harness.charm.model.resources,
+            self.harness.charm._stored.enabled_hw_tool_list_values,
         )
 
         self.harness.charm.unit.status = ActiveStatus("Install complete")
@@ -117,11 +121,12 @@ class TestCharm(unittest.TestCase):
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
     def test_install_redfish_unavailable(self, mock_hw_tool_helper, mock_exporter) -> None:
         """Test install event handler when redfish is unavailable."""
-        self.mock_bmc_hw_verifier.return_value = [
+        mock_enabled_hw_tool_list = [
             HWTool.IPMI_SENSOR,
             HWTool.IPMI_SEL,
             HWTool.IPMI_DCMI,
         ]
+        self.mock_get_hw_tool_enable_list.return_value = mock_enabled_hw_tool_list
         mock_hw_tool_helper.return_value.install.return_value = (True, "")
         mock_exporter.return_value.install.return_value = True
         self.harness.begin()
@@ -134,6 +139,7 @@ class TestCharm(unittest.TestCase):
             "INFO",  # default in config.yaml
             {},
             10,  # default int config.yaml
+            mock_enabled_hw_tool_list,
         )
 
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())
@@ -158,7 +164,7 @@ class TestCharm(unittest.TestCase):
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
     def test_update_status_all_green(self, mock_hw_tool_helper, mock_exporter):
         """Test update_status event handler when everything is okay."""
-        self.mock_bmc_hw_verifier.return_value = [
+        self.mock_get_hw_tool_enable_list.return_value = [
             HWTool.IPMI_SENSOR,
             HWTool.IPMI_SEL,
             HWTool.IPMI_DCMI,
@@ -178,7 +184,7 @@ class TestCharm(unittest.TestCase):
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
     def test_update_status_check_installed_false(self, mock_hw_tool_helper, mock_exporter):
         """Test update_status event handler when hw tool checks failed."""
-        self.mock_bmc_hw_verifier.return_value = [
+        self.mock_get_hw_tool_enable_list.return_value = [
             HWTool.IPMI_SENSOR,
             HWTool.IPMI_SEL,
             HWTool.IPMI_DCMI,
@@ -198,7 +204,7 @@ class TestCharm(unittest.TestCase):
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
     def test_update_status_exporter_crashed(self, mock_hw_tool_helper, mock_exporter):
         """Test update_status."""
-        self.mock_bmc_hw_verifier.return_value = [
+        self.mock_get_hw_tool_enable_list.return_value = [
             HWTool.IPMI_SENSOR,
             HWTool.IPMI_SEL,
             HWTool.IPMI_DCMI,
@@ -212,10 +218,9 @@ class TestCharm(unittest.TestCase):
         with self.assertRaises(ExporterError):
             self.harness.charm.on.update_status.emit()
 
-    @mock.patch.object(charm, "bmc_hw_verifier", return_value=[])
     @mock.patch("charm.HWToolHelper")
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())
-    def test_config_changed(self, mock_exporter, mock_hw_tool_helper, mock_bmc_hw_verifier):
+    def test_config_changed(self, mock_exporter, mock_hw_tool_helper):
         """Test config change event renders config file."""
         self.harness.begin()
         self.harness.charm._stored.resource_installed = True
@@ -233,12 +238,9 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(self.harness.charm.unit.status, ActiveStatus("Unit is ready"))
 
-    @mock.patch.object(charm, "bmc_hw_verifier", return_value=[])
     @mock.patch("charm.HWToolHelper")
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())
-    def test_config_changed_without_cos_agent_relation(
-        self, mock_exporter, mock_hw_tool_helper, mock_bmc_hw_verifier
-    ):
+    def test_config_changed_without_cos_agent_relation(self, mock_exporter, mock_hw_tool_helper):
         """Test config change event don't render config file if cos_agent relation is missing."""
         self.harness.begin()
         self.harness.charm._stored.resource_installed = True
@@ -275,7 +277,7 @@ class TestCharm(unittest.TestCase):
         mock_exporter.return_value.install.return_value = True
         self.harness.begin()
         self.harness.charm._stored.exporter_installed = True
-        print(dir(self.harness.charm.on))
+        self.harness.charm._stored.enabled_hw_tool_list_values = []
         self.harness.charm.on.upgrade_charm.emit()
 
         self.assertTrue(self.harness.charm._stored.resource_installed)
@@ -283,14 +285,15 @@ class TestCharm(unittest.TestCase):
 
         self.harness.charm.exporter.install.assert_called_once()
         self.harness.charm.hw_tool_helper.install.assert_called_with(
-            self.harness.charm.model.resources
+            self.harness.charm.model.resources,
+            self.harness.charm._stored.enabled_hw_tool_list_values,
         )
 
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
     def test_update_status_config_invalid(self, mock_hw_tool_helper, mock_exporter):
         """Test update_status event handler when config is invalid."""
-        self.mock_bmc_hw_verifier.return_value = [
+        self.mock_get_hw_tool_enable_list.return_value = [
             HWTool.IPMI_SENSOR,
             HWTool.IPMI_SEL,
             HWTool.IPMI_DCMI,
@@ -313,7 +316,7 @@ class TestCharm(unittest.TestCase):
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
     def test_config_changed_update_alert_rules(self, mock_hw_tool_helper, mock_exporter):
         """Test config changed will update alert rule."""
-        self.mock_bmc_hw_verifier.return_value = [
+        self.mock_get_hw_tool_enable_list.return_value = [
             HWTool.IPMI_SENSOR,
             HWTool.IPMI_SEL,
             HWTool.IPMI_DCMI,
@@ -349,7 +352,7 @@ class TestCharm(unittest.TestCase):
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
     def test_upgrade_charm_update_alert_rules(self, mock_hw_tool_helper, mock_exporter):
         """Test upgrade charm event updates alert rule."""
-        self.mock_bmc_hw_verifier.return_value = [
+        self.mock_get_hw_tool_enable_list.return_value = [
             HWTool.IPMI_SENSOR,
             HWTool.IPMI_SEL,
             HWTool.IPMI_DCMI,
@@ -387,9 +390,10 @@ class TestCharm(unittest.TestCase):
         self, mock_hw_tool_helper, mock_exporter
     ) -> None:
         """Test install event when redfish is available and credential is correct."""
-        self.mock_bmc_hw_verifier.return_value = [
+        mock_enabled_hw_tool_list = [
             HWTool.REDFISH,
         ]
+        self.mock_get_hw_tool_enable_list.return_value = mock_enabled_hw_tool_list
         mock_hw_tool_helper.return_value.install.return_value = (True, "")
         mock_exporter.return_value.install.return_value = True
         self.harness.begin()
@@ -400,8 +404,9 @@ class TestCharm(unittest.TestCase):
         self.harness.charm.exporter.install.assert_called_with(
             10200,  # default in config.yaml
             "INFO",  # default in config.yaml
-            self.harness.charm.get_redfish_conn_params(),
+            self.harness.charm.get_redfish_conn_params(mock_enabled_hw_tool_list),
             10,  # default int config.yaml
+            mock_enabled_hw_tool_list,
         )
 
     @parameterized.expand([(InvalidCredentialsError), (Exception)])
@@ -412,7 +417,7 @@ class TestCharm(unittest.TestCase):
         self, test_exception, mock_redfish_client, mock_hw_tool_helper, mock_exporter
     ) -> None:
         """Test event install when redfish is available but credential is wrong."""
-        self.mock_bmc_hw_verifier.return_value = [
+        self.mock_get_hw_tool_enable_list.return_value = [
             HWTool.REDFISH,
         ]
         mock_redfish_client.side_effect = test_exception()
@@ -438,15 +443,16 @@ class TestCharm(unittest.TestCase):
     @mock.patch("charm.Exporter", return_value=mock.MagicMock())
     @mock.patch("charm.HWToolHelper", return_value=mock.MagicMock())
     @mock.patch("charm.redfish_client", return_value=mock.MagicMock())
+    @mock.patch("charm.HardwareObserverCharm._stored")
     def test_config_changed_redfish_enabled_with_incorrect_credential(
-        self, test_exception, mock_redfish_client, mock_hw_tool_helper, mock_exporter
+        self, test_exception, mock_stored, mock_redfish_client, mock_hw_tool_helper, mock_exporter
     ) -> None:
         """Test event config changed when redfish is available but credential is wrong."""
-        self.mock_bmc_hw_verifier.return_value = [
-            HWTool.IPMI_SENSOR,
-            HWTool.IPMI_SEL,
-            HWTool.IPMI_DCMI,
-            HWTool.REDFISH,
+        mock_stored.enabled_hw_tool_list_values = [
+            "ipmi_sensor",
+            "ipmi_sel",
+            "ipmi_dcmi",
+            "redfish",
         ]
         mock_hw_tool_helper.return_value.install.return_value = (True, "")
         mock_hw_tool_helper.return_value.check_installed.return_value = (True, "")
@@ -459,6 +465,7 @@ class TestCharm(unittest.TestCase):
         new_config = {
             "exporter-port": 80,
             "exporter-log-level": "DEBUG",
+            "collect-timeout": 10,
             "redfish-username": "redfish",
             "redfish-password": "redfish",
         }

--- a/tests/unit/test_exporter.py
+++ b/tests/unit/test_exporter.py
@@ -38,20 +38,16 @@ class TestExporter(unittest.TestCase):
         mock_hw_tool_helper.return_value.check_installed.return_value = [True, ""]
         self.addCleanup(hw_tool_lib_patcher.stop)
 
-        get_hw_tool_white_list_patcher = mock.patch.object(service, "get_hw_tool_white_list")
-        get_hw_tool_white_list_patcher.start()
-        self.addCleanup(get_hw_tool_white_list_patcher.stop)
-
         get_bmc_address_patcher = mock.patch("charm.get_bmc_address", return_value="127.0.0.1")
         get_bmc_address_patcher.start()
         self.addCleanup(get_bmc_address_patcher.stop)
 
-        bmc_hw_verifier_patcher = mock.patch(
-            "charm.bmc_hw_verifier",
+        get_charm_hw_tool_enable_list_patcher = mock.patch(
+            "charm.get_hw_tool_enable_list",
             return_value=[HWTool.IPMI_SENSOR, HWTool.IPMI_SEL, HWTool.IPMI_DCMI, HWTool.REDFISH],
         )
-        bmc_hw_verifier_patcher.start()
-        self.addCleanup(bmc_hw_verifier_patcher.stop)
+        get_charm_hw_tool_enable_list_patcher.start()
+        self.addCleanup(get_charm_hw_tool_enable_list_patcher.stop)
 
         redfish_client_patcher = mock.patch("charm.redfish_client")
         redfish_client_patcher.start()
@@ -336,17 +332,14 @@ class TestExporterTemplate(unittest.TestCase):
         search_path = pathlib.Path(f"{__file__}/../../..").resolve()
         self.template = service.ExporterTemplate(search_path)
 
-    @mock.patch(
-        "service.get_hw_tool_white_list",
-        return_value=[HWTool.STORCLI, HWTool.SSACLI],
-    )
-    def test_render_config(self, mock_get_hw_tool_white_list):
+    def test_render_config(self):
         with mock.patch.object(self.template, "_install") as mock_install:
             self.template.render_config(
                 port="80",
                 level="info",
                 redfish_conn_params={},
                 collect_timeout=10,
+                hw_tools=[HWTool.STORCLI, HWTool.SSACLI],
             )
             mock_install.assert_called_with(
                 EXPORTER_CONFIG_PATH,
@@ -362,11 +355,7 @@ class TestExporterTemplate(unittest.TestCase):
                 ),
             )
 
-    @mock.patch(
-        "service.get_hw_tool_white_list",
-        return_value=[HWTool.REDFISH],
-    )
-    def test_render_config_redfish(self, mock_get_hw_tool_white_list):
+    def test_render_config_redfish(self):
         with mock.patch.object(self.template, "_install") as mock_install:
             self.template.render_config(
                 port="80",
@@ -377,6 +366,7 @@ class TestExporterTemplate(unittest.TestCase):
                     "username": "default_user",
                     "password": "default_pwd",
                 },
+                hw_tools=[HWTool.REDFISH],
             )
             mock_install.assert_called_with(
                 EXPORTER_CONFIG_PATH,

--- a/tests/unit/test_hw_tools.py
+++ b/tests/unit/test_hw_tools.py
@@ -41,7 +41,7 @@ from hw_tools import (
     check_deb_pkg_installed,
     copy_to_snap_common_bin,
     file_is_empty,
-    get_hw_tool_white_list,
+    get_hw_tool_enable_list,
     install_deb,
     make_executable,
     raid_hw_verifier,
@@ -141,7 +141,7 @@ class TestHWToolHelper(unittest.TestCase):
 
         self.hw_tool_helper.fetch_tools(
             resources=mock_resources,
-            hw_white_list=[tool for tool in HWTool],
+            hw_enable_list=[tool for tool in HWTool],
         )
 
         for tool in TPR_RESOURCES.values():
@@ -155,7 +155,7 @@ class TestHWToolHelper(unittest.TestCase):
 
         fetch_tools = self.hw_tool_helper.fetch_tools(
             mock_resources,
-            hw_white_list=[tool for tool in HWTool],
+            hw_enable_list=[tool for tool in HWTool],
         )
 
         for tool in TPR_RESOURCES.values():
@@ -163,7 +163,6 @@ class TestHWToolHelper(unittest.TestCase):
 
         self.assertEqual(fetch_tools, {})
 
-    @mock.patch("hw_tools.get_hw_tool_white_list")
     @mock.patch(
         "hw_tools.HWToolHelper.strategies",
         return_value=[
@@ -172,7 +171,7 @@ class TestHWToolHelper(unittest.TestCase):
         ],
         new_callable=mock.PropertyMock,
     )
-    def test_04_install(self, mock_strategies, mock_hw_white_list):
+    def test_04_install(self, mock_strategies):
         """Check strategy is been called."""
         self.harness.add_resource("storcli-deb", "storcli.deb")
         self.harness.begin()
@@ -180,11 +179,11 @@ class TestHWToolHelper(unittest.TestCase):
 
         mock_strategies.return_value[0].name = HWTool.STORCLI
 
-        mock_hw_white_list.return_value = []
+        mock_hw_enable_list = []
         for strategy in mock_strategies.return_value:
-            mock_hw_white_list.return_value.append(strategy.name)
+            mock_hw_enable_list.append(strategy.name)
 
-        self.hw_tool_helper.install(mock_resources)
+        self.hw_tool_helper.install(mock_resources, mock_hw_enable_list)
 
         for strategy in mock_strategies.return_value:
             if isinstance(strategy, TPRStrategyABC):
@@ -193,7 +192,6 @@ class TestHWToolHelper(unittest.TestCase):
             elif isinstance(strategy, APTStrategyABC):
                 strategy.install.assert_any_call()
 
-    @mock.patch("hw_tools.get_hw_tool_white_list", return_value=[HWTool.STORCLI])
     @mock.patch(
         "hw_tools.HWToolHelper.strategies",
         return_value=[
@@ -201,15 +199,15 @@ class TestHWToolHelper(unittest.TestCase):
         ],
         new_callable=mock.PropertyMock,
     )
-    def test_05_remove(self, mock_strategies, _):
+    def test_05_remove(self, mock_strategies):
         self.harness.begin()
         mock_resources = self.harness.charm.model.resources
         mock_strategies.return_value[0].name = HWTool.STORCLI
-        self.hw_tool_helper.remove(mock_resources)
+        mock_hw_enable_list = [HWTool.STORCLI]
+        self.hw_tool_helper.remove(mock_resources, mock_hw_enable_list)
         for strategy in mock_strategies.return_value:
             strategy.remove.assert_called()
 
-    @mock.patch("hw_tools.get_hw_tool_white_list")
     @mock.patch(
         "hw_tools.HWToolHelper.strategies",
         return_value=[
@@ -218,7 +216,7 @@ class TestHWToolHelper(unittest.TestCase):
         ],
         new_callable=mock.PropertyMock,
     )
-    def test_06_install_not_in_white_list(self, mock_strategies, mock_hw_white_list):
+    def test_06_install_not_in_enable_list(self, mock_strategies):
         """Check strategy is been called."""
         self.harness.add_resource("storcli-deb", "storcli.deb")
         self.harness.begin()
@@ -226,21 +224,20 @@ class TestHWToolHelper(unittest.TestCase):
 
         mock_strategies.return_value[0].name = HWTool.STORCLI
 
-        mock_hw_white_list.return_value = []
+        mock_hw_enable_list = []
 
-        self.hw_tool_helper.install(mock_resources)
+        self.hw_tool_helper.install(mock_resources, mock_hw_enable_list)
 
         for strategy in mock_strategies.return_value:
             strategy.install.assert_not_called()
 
     @mock.patch("hw_tools.TPR_RESOURCES", {})
-    @mock.patch("hw_tools.get_hw_tool_white_list")
     @mock.patch(
         "hw_tools.HWToolHelper.strategies",
         return_value=[mock.MagicMock(spec=TPRStrategyABC)],
         new_callable=mock.PropertyMock,
     )
-    def test_07_install_no_resource(self, mock_strategies, mock_hw_white_list):
+    def test_07_install_no_resource(self, mock_strategies):
         """Check tpr strategy is not been called if resource is not defined."""
         self.harness.add_resource("storcli-deb", "storcli.deb")
         self.harness.begin()
@@ -248,16 +245,15 @@ class TestHWToolHelper(unittest.TestCase):
 
         mock_strategies.return_value[0].name = HWTool.STORCLI
 
-        mock_hw_white_list.return_value = []
+        mock_hw_enable_list = []
         for strategy in mock_strategies.return_value:
-            mock_hw_white_list.return_value.append(strategy.name)
+            mock_hw_enable_list.append(strategy.name)
 
-        self.hw_tool_helper.install(mock_resources)
+        self.hw_tool_helper.install(mock_resources, mock_hw_enable_list)
 
         for strategy in mock_strategies.return_value:
             strategy.install.assert_not_called()
 
-    @mock.patch("hw_tools.get_hw_tool_white_list", return_value=[])
     @mock.patch(
         "hw_tools.HWToolHelper.strategies",
         return_value=[
@@ -265,15 +261,15 @@ class TestHWToolHelper(unittest.TestCase):
         ],
         new_callable=mock.PropertyMock,
     )
-    def test_08_remove_not_in_white_list(self, mock_strategies, _):
+    def test_08_remove_not_in_enable_list(self, mock_strategies):
         self.harness.begin()
         mock_resources = self.harness.charm.model.resources
         mock_strategies.return_value[0].name = HWTool.STORCLI
-        self.hw_tool_helper.remove(mock_resources)
+        mock_hw_enable_list = []
+        self.hw_tool_helper.remove(mock_resources, mock_hw_enable_list)
         for strategy in mock_strategies.return_value:
             strategy.remove.assert_not_called()
 
-    @mock.patch("hw_tools.get_hw_tool_white_list", return_value=[HWTool.STORCLI, HWTool.PERCCLI])
     @mock.patch(
         "hw_tools.HWToolHelper.strategies",
         return_value=[
@@ -281,24 +277,17 @@ class TestHWToolHelper(unittest.TestCase):
         ],
         new_callable=mock.PropertyMock,
     )
-    def test_09_install_required_resource_not_uploaded(self, _, mock_hw_white_list):
+    def test_09_install_required_resource_not_uploaded(self, _):
         self.harness.begin()
         mock_resources = self.harness.charm.model.resources
-        ok, msg = self.hw_tool_helper.install(mock_resources)
+        mock_hw_enable_list = [HWTool.STORCLI, HWTool.PERCCLI]
+        ok, msg = self.hw_tool_helper.install(mock_resources, mock_hw_enable_list)
         self.assertFalse(ok)
         self.assertTrue("storcli-deb" in msg)
         self.assertTrue("perccli-deb" in msg)
         self.assertFalse(self.harness.charm._stored.resource_installed)
 
     @mock.patch(
-        "hw_tools.get_hw_tool_white_list",
-        return_value=[
-            HWTool.STORCLI,
-            HWTool.IPMI_SENSOR,
-            HWTool.REDFISH,
-        ],
-    )
-    @mock.patch(
         "hw_tools.HWToolHelper.strategies",
         return_value=[
             mock.PropertyMock(spec=TPRStrategyABC),
@@ -307,7 +296,7 @@ class TestHWToolHelper(unittest.TestCase):
         ],
         new_callable=mock.PropertyMock,
     )
-    def test_10_install_strategy_errors(self, mock_strategies, mock_hw_white_list):
+    def test_10_install_strategy_errors(self, mock_strategies):
         """Catch excepted error when execute strategies' install method."""
         self.harness.add_resource("storcli-deb", "storcli.deb")
         self.harness.begin()
@@ -323,8 +312,13 @@ class TestHWToolHelper(unittest.TestCase):
         mock_strategies.return_value[2].install.side_effect = apt.PackageError(
             "Fake apt package error"
         )
+        mock_hw_enable_list = [
+            HWTool.STORCLI,
+            HWTool.IPMI_SENSOR,
+            HWTool.REDFISH,
+        ]
 
-        ok, msg = self.hw_tool_helper.install(mock_resources)
+        ok, msg = self.hw_tool_helper.install(mock_resources, mock_hw_enable_list)
 
         self.assertFalse(ok)
         self.assertEqual(
@@ -336,13 +330,12 @@ class TestHWToolHelper(unittest.TestCase):
     def test_11_check_missing_resources_zero_size_resources(self, file_is_empty):
         self.harness.begin()
         ok, msg = self.hw_tool_helper.check_missing_resources(
-            hw_white_list=[HWTool.STORCLI],
+            hw_enable_list=[HWTool.STORCLI],
             fetch_tools={HWTool.STORCLI: "fake-path"},
         )
         self.assertFalse(ok)
         self.assertEqual("Missing resources: ['storcli-deb']", msg)
 
-    @mock.patch("hw_tools.get_hw_tool_white_list", return_value=[HWTool.STORCLI])
     @mock.patch(
         "hw_tools.HWToolHelper.strategies",
         return_value=[
@@ -350,14 +343,14 @@ class TestHWToolHelper(unittest.TestCase):
         ],
         new_callable=mock.PropertyMock,
     )
-    def test_12_check_installed_okay(self, mock_strategies, _):
+    def test_12_check_installed_okay(self, mock_strategies):
         self.harness.begin()
         mock_strategies.return_value[0].name = HWTool.STORCLI
-        self.hw_tool_helper.check_installed()
+        mock_hw_enable_list = [HWTool.STORCLI]
+        self.hw_tool_helper.check_installed(mock_hw_enable_list)
         for strategy in mock_strategies.return_value:
             strategy.check.assert_called()
 
-    @mock.patch("hw_tools.get_hw_tool_white_list", return_value=[HWTool.STORCLI])
     @mock.patch(
         "hw_tools.HWToolHelper.strategies",
         return_value=[
@@ -365,18 +358,19 @@ class TestHWToolHelper(unittest.TestCase):
         ],
         new_callable=mock.PropertyMock,
     )
-    def test_13_check_installed_okay(self, mock_strategies, _):
+    def test_13_check_installed_okay(self, mock_strategies):
         self.harness.begin()
         mock_strategies.return_value[0].name = HWTool.SSACLI
-        success, msg = self.hw_tool_helper.check_installed()
+        mock_hw_enable_list = [HWTool.STORCLI]
+        success, msg = self.hw_tool_helper.check_installed(mock_hw_enable_list)
         self.assertTrue(success)
         self.assertEqual(msg, "")
 
     @mock.patch("hw_tools.os")
     @mock.patch("hw_tools.Path")
-    @mock.patch(
-        "hw_tools.get_hw_tool_white_list",
-        return_value=[
+    def test_14_check_installed_not_okay(self, mock_os, mock_path):
+        self.harness.begin()
+        mock_hw_enable_list = [
             HWTool.STORCLI,
             HWTool.PERCCLI,
             HWTool.SAS2IRCU,
@@ -386,11 +380,8 @@ class TestHWToolHelper(unittest.TestCase):
             HWTool.IPMI_SEL,
             HWTool.IPMI_DCMI,
             HWTool.REDFISH,
-        ],
-    )
-    def test_14_check_installed_not_okay(self, _, mock_os, mock_path):
-        self.harness.begin()
-        success, msg = self.hw_tool_helper.check_installed()
+        ]
+        success, msg = self.hw_tool_helper.check_installed(mock_hw_enable_list)
         self.assertFalse(success)
 
 
@@ -739,8 +730,9 @@ class TestIPMIDCMIStrategy(unittest.TestCase):
 
 @mock.patch("hw_tools.bmc_hw_verifier", return_value=[1, 2, 3])
 @mock.patch("hw_tools.raid_hw_verifier", return_value=[4, 5, 6])
-def test_get_hw_tool_white_list(mock_raid_verifier, mock_bmc_hw_verifier):
-    output = get_hw_tool_white_list()
+def test_get_hw_tool_enable_list(mock_raid_verifier, mock_bmc_hw_verifier):
+    get_hw_tool_enable_list.cache_clear()
+    output = get_hw_tool_enable_list()
     mock_raid_verifier.assert_called()
     mock_bmc_hw_verifier.assert_called()
     assert output == [4, 5, 6, 1, 2, 3]


### PR DESCRIPTION
Fix: #96 
- Now the hardware tool list only detect once when first time the install/upgrade hook is triggered and the list is stored in the local Store.
- Provide a juju action `redetect-hardware` to run the detect again.
  - Default is dry-run, need `apply=true` to update the tool list and the action will also trigger the install hook again. 