### PR TITLE
fix: Pin pytest version

### DIFF
--- a/tests/functional/requirements.txt
+++ b/tests/functional/requirements.txt
@@ -1,5 +1,8 @@
 async-lru
-pytest
+# pytest-8.2.0 with asyncio-0.21.1 breaks func tests with error:
+# AttributeError: 'FixtureDef' object has no attribute 'unittest'.
+# https://github.com/charmed-kubernetes/pytest-operator/issues/131
+pytest==8.1.1
 pytest-operator
 # Keep protobuf < 4.0 until macaroonbakery solves its incompatibility
 # https://github.com/go-macaroon-bakery/py-macaroon-bakery/issues/94

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,6 +1,9 @@
 jinja2
 juju~=3.1.0  # must be compatible with the juju CLI version installed by CI
-pytest
+# pytest-8.2.0 with asyncio-0.21.1 breaks func tests with error:
+# AttributeError: 'FixtureDef' object has no attribute 'unittest'.
+# https://github.com/charmed-kubernetes/pytest-operator/issues/131
+pytest==8.1.1
 pytest-operator
 prometheus-client
 pyinstaller # required to bundle export_mock_metrics script to send it to hw-oberver unit


### PR DESCRIPTION
When using pytest-8.2.0 with async-0.21.1, func tests throw an error:

`AttributeError: 'FixtureDef' object has no attribute 'unittest'`

Refer: https://github.com/charmed-kubernetes/pytest-operator/issues/131

Therefore, the pytest version is pinned till the issue is resolved upstream.