### PR TITLE
Fix typing issue

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -141,7 +141,7 @@ class HardwareObserverCharm(ops.CharmBase):
         self.model.unit.status = MaintenanceStatus("Installing exporter...")
         success = self.exporter.install(
             int(self.model.config["exporter-port"]),
-            self.model.config["exporter-log-level"],
+            str(self.model.config["exporter-log-level"]),
             self.get_redfish_conn_params(enabled_hw_tool_list),
             int(self.model.config["collect-timeout"]),
             enabled_hw_tool_list,
@@ -239,7 +239,7 @@ class HardwareObserverCharm(ops.CharmBase):
 
             success = self.exporter.template.render_config(
                 port=int(self.model.config["exporter-port"]),
-                level=self.model.config["exporter-log-level"],
+                level=str(self.model.config["exporter-log-level"]),
                 redfish_conn_params=self.get_redfish_conn_params(
                     self.get_hw_tools_from_values(self.get_enabled_hw_tool_list_values())
                 ),
@@ -297,7 +297,7 @@ class HardwareObserverCharm(ops.CharmBase):
             logger.error("Invalid exporter-port: port must be in [1, 65535].")
             return False, "Invalid config: 'exporter-port'"
 
-        level = self.model.config["exporter-log-level"]
+        level = str(self.model.config["exporter-log-level"])
         allowed_choices = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
         if level.upper() not in allowed_choices:
             logger.error(


### PR DESCRIPTION
After operator framework fixes the incorrect types in `model.config` [1], it introduces some issues in our existing codebases since we used to assume them to have type of `str` which is not correct in the first place.

[1] https://github.com/canonical/operator/pull/1183