### PR TITLE
Add alert rules for SMART metrics

### DIFF
--- a/src/prometheus_alert_rules/smart.yaml
+++ b/src/prometheus_alert_rules/smart.yaml
@@ -1,0 +1,101 @@
+groups:
+- name: SMART
+  rules:
+
+  - alert: SmartNVMeDriveReliabilityDegraded
+    # isolate the least significant three bits with % 8
+    # check whether bit 2 (starts from bit 0) has been set with the >= 4 comparison
+    # refer: https://en.wikipedia.org/wiki/Self-Monitoring,_Analysis_and_Reporting_Technology#Known_NVMe_S.M.A.R.T._attributes
+    expr: smartctl_device_critical_warning % 8 >= 4
+    for: 15m
+    labels:
+      severity: critical
+    annotations:
+      summary: SMART alert for critical warning attribute on an NVMe controller due to degradation in drive reliability. (instance {{ $labels.instance }})
+      description: |
+        Drive reliability is degraded. Bit 2 of critical warning SMART attribute is set.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
+
+  - alert: SmartNVMeDriveinReadOnlyMode
+    # isolate the least significant four bits with % 16
+    # check whether bit 3 (starts from bit 0) has been set with the >= 8 comparison
+    # refer: https://en.wikipedia.org/wiki/Self-Monitoring,_Analysis_and_Reporting_Technology#Known_NVMe_S.M.A.R.T._attributes
+    expr: smartctl_device_critical_warning % 16 >= 8
+    for: 15m
+    labels:
+      severity: critical
+    annotations:
+      summary: SMART alert for critical warning attribute on an NVMe controller due to drive being in read-only mode. (instance {{ $labels.instance }})
+      description: |
+        Drive is in read-only mode. Bit 3 of critical warning SMART attribute is set.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
+
+  - alert: SmartHealthStatusFail
+    expr: smartctl_device_smart_status == 0
+    for: 2m
+    labels:
+      severity: critical
+    annotations:
+      summary: SMART health status failed for device. (instance {{ $labels.instance }})
+      description: |
+        SMART health status failed for device. This means either that the device has already failed, or that it is predicting its own failure within the next 24 hours.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
+
+  - alert: SmartExitStatusDiskFail
+    # isolate the least significant four bits with % 16
+    # check whether bit 3 (starts from bit 0) has been set with the >= 8 comparison
+    # refer: https://www.smartmontools.org/browser/trunk/smartmontools/smartctl.8.in#EXIT_STATUS
+    expr: smartctl_device_smartctl_exit_status % 16 >= 8
+    for: 2m
+    labels:
+      severity: critical
+    annotations:
+      summary: smartctl exit status returned "DISK FAILING". (instance {{ $labels.instance }})
+      description: |
+        smartctl exit status returned "DISK FAILING". Bit 3 of smartctl exit status is set.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
+
+  - alert: SmartExitStatusPrefailBelowThreshold
+    # isolate the least significant four bits with % 32
+    # check whether bit 4 (starts from bit 0) has been set with the >= 16 comparison
+    # refer: https://www.smartmontools.org/browser/trunk/smartmontools/smartctl.8.in#EXIT_STATUS
+    expr: smartctl_device_smartctl_exit_status % 32 >= 16
+    for: 2m
+    labels:
+      severity: warning
+    annotations:
+      summary: smartctl exit status reports pre-fail attribute for device is below threshold. (instance {{ $labels.instance }})
+      description: |
+        smartctl exit status pre-fail attribute is below threshold. Bit 4 of smartctl exit status is set.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
+
+  - alert: SmartNVMeWearoutIndicator
+    expr: smartctl_device_available_spare{device=~"nvme.*"} < smartctl_device_available_spare_threshold{device=~"nvme.*"}
+    for: 15m
+    labels:
+      severity: critical
+    annotations:
+      summary: SMART alert for available spare space below threshold for NVMe device. (instance {{ $labels.instance }})
+      description: |
+        Available spare space below threshold for NVMe device.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
+
+  - alert: SmartAttributeWarning
+    # based on https://www.backblaze.com/blog/what-smart-stats-indicate-hard-drive-failures/
+    expr: smartctl_device_attribute{attribute_id=~"5|187|188|197|198"} > 0
+    for: 2m
+    labels:
+      severity: warning
+    annotations:
+      summary: SMART device attribute correlating with drive failure has its raw value greater than zero. (instance {{ $labels.instance }})
+      description: |
+        SMART raw value for attribute "{{ $labels.attribute_name }}" with id "{{ $labels.attribute_id }}"
+        on device "{{ $labels.device }}" is greater than 0.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}

--- a/tests/unit/test_alert_rules/test_smart.yaml
+++ b/tests/unit/test_alert_rules/test_smart.yaml
@@ -1,0 +1,190 @@
+rule_files:
+  - ../../../src/prometheus_alert_rules/smart.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_device_critical_warning{device="sda", instance="ubuntu-0"}'
+        values: '6x15' # 6 = 0b0110
+
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: SmartNVMeDriveReliabilityDegraded
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              instance: ubuntu-0
+              device: sda
+            exp_annotations:
+              summary: SMART alert for critical warning attribute on an NVMe controller due to degradation in drive reliability. (instance ubuntu-0)
+              description: |
+                Drive reliability is degraded. Bit 2 of critical warning SMART attribute is set.
+                  VALUE = 6
+                  LABELS = map[device:sda instance:ubuntu-0]
+
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_device_critical_warning{device="sda", instance="ubuntu-0"}'
+        values: '10x15' # 10 = 0b1010
+
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: SmartNMVeDriveReliabilityDegraded
+        exp_alerts: # alerts shouldn't fire since bit 2 isn't set
+
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_device_critical_warning{device="sda", instance="ubuntu-0"}'
+        values: '9x15' # 9 = 0b1001
+
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: SmartNVMeDriveinReadOnlyMode
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              instance: ubuntu-0
+              device: sda
+            exp_annotations:
+              summary: SMART alert for critical warning attribute on an NVMe controller due to drive being in read-only mode. (instance ubuntu-0)
+              description: |
+                Drive is in read-only mode. Bit 3 of critical warning SMART attribute is set.
+                  VALUE = 9
+                  LABELS = map[device:sda instance:ubuntu-0]
+
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_device_critical_warning{device="sda", instance="ubuntu-0"}'
+        values: '5x15' # 5 = 0b0101
+
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: SmartNVMeDriveinReadOnlyMode
+        exp_alerts: # alerts shouldn't fire since bit 3 isn't set
+
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_device_smart_status{device="sda", instance="ubuntu-1"}'
+        values: '0x15'
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: SmartHealthStatusFail
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              instance: ubuntu-1
+              device: sda
+            exp_annotations:
+              summary: SMART health status failed for device. (instance ubuntu-1)
+              description: |
+                SMART health status failed for device. This means either that the device has already failed, or that it is predicting its own failure within the next 24 hours.
+                  VALUE = 0
+                  LABELS = map[__name__:smartctl_device_smart_status device:sda instance:ubuntu-1]
+
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_device_smartctl_exit_status{device="sda", instance="ubuntu-2"}'
+        values: '75x10' # 75 = 0b01001011
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: SmartExitStatusDiskFail
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              instance: ubuntu-2
+              device: sda
+            exp_annotations:
+              summary: smartctl exit status returned "DISK FAILING". (instance ubuntu-2)
+              description: |
+                smartctl exit status returned "DISK FAILING". Bit 3 of smartctl exit status is set.
+                  VALUE = 11
+                  LABELS = map[device:sda instance:ubuntu-2]
+
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_device_smartctl_exit_status{device="sda", instance="ubuntu-2"}'
+        values: '67x10' # 67 = 0b01000011
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: SmartExitStatusDiskFail
+        exp_alerts: # alerts shouldn't fire since bit 3 isn't set
+
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_device_smartctl_exit_status{device="sda", instance="ubuntu-2"}'
+        values: '82x10' # 82 = 0b01010010
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: SmartExitStatusPrefailBelowThreshold
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: ubuntu-2
+              device: sda
+            exp_annotations:
+              summary: smartctl exit status reports pre-fail attribute for device is below threshold. (instance ubuntu-2)
+              description: |
+                smartctl exit status pre-fail attribute is below threshold. Bit 4 of smartctl exit status is set.
+                  VALUE = 18
+                  LABELS = map[device:sda instance:ubuntu-2]
+
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_device_smartctl_exit_status{device="sda", instance="ubuntu-2"}'
+        values: '66x10' # 66 = 0b01000010
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: SmartExitStatusPrefailBelowThreshold
+        exp_alerts: # alerts shouldn't fire since bit 4 isn't set
+
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_device_available_spare{device="nvme", instance="ubuntu-2"}'
+        values: '4x15'
+      - series: 'smartctl_device_available_spare_threshold{device="nvme", instance="ubuntu-2"}'
+        values: '5x15'
+
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: SmartNVMeWearoutIndicator
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              instance: ubuntu-2
+              device: nvme
+            exp_annotations:
+              summary: SMART alert for available spare space below threshold for NVMe device. (instance ubuntu-2)
+              description: |
+                Available spare space below threshold for NVMe device.
+                  VALUE = 4
+                  LABELS = map[__name__:smartctl_device_available_spare device:nvme instance:ubuntu-2]
+
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_device_attribute{device="sda", attribute_id="5", attribute_name="Reallocated_Sectors_Count", instance="ubuntu-2"}'
+        values: '2x10'
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: SmartAttributeWarning
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: ubuntu-2
+              device: sda
+              attribute_id: 5
+              attribute_name: Reallocated_Sectors_Count
+            exp_annotations:
+              summary: SMART device attribute correlating with drive failure has its raw value greater than zero. (instance ubuntu-2)
+              description: |
+                SMART raw value for attribute "Reallocated_Sectors_Count" with id "5"
+                on device "sda" is greater than 0.
+                  VALUE = 2
+                  LABELS = map[__name__:smartctl_device_attribute attribute_id:5 attribute_name:Reallocated_Sectors_Count device:sda instance:ubuntu-2]


### PR DESCRIPTION
The discussion for this PR is in https://github.com/canonical/hardware-observer-operator/pull/238 but there was an issue with the merge over multiple commits to the dev branch. So I've consolidated the changes to one commit here and pushing it to main itself since it doesn't affect any other functionality.