### PR TITLE
docs: Add comment for resource_installed

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -44,6 +44,8 @@ class HardwareObserverCharm(ops.CharmBase):
         )
 
         self._stored.set_default(
+            # resource_installed is a flag that tracks the installation state for
+            # the juju resources and also the different exporters
             resource_installed=False,
             # Storing only the values from `HWTool` because entire HWTool
             # cannot be stored in _stored. Only simple types can be stored.


### PR DESCRIPTION
Resolves #252 

The original issue is incorrect since the charm *will* go into blocked state if the exporter install fails. But the stored state variable that we use to track this might be misleading. So I've added a comment to make this clearer.