### PR TITLE
Update functional test to match grafana-agent update.

### DIFF
--- a/tests/functional/test_charm.py
+++ b/tests/functional/test_charm.py
@@ -117,7 +117,7 @@ async def test_build_and_deploy(  # noqa: C901, function is too complex
             assert unit.workload_status_message == AppStatus.MISSING_RELATION
 
     for unit in ops_test.model.applications[GRAFANA_AGENT_APP_NAME].units:
-        messages = ["grafana-cloud-config: off", "logging-consumer: off", "send-remote-write: off"]
+        messages = ["Missing", "grafana-cloud-config", "logging-consumer", "send-remote-write"]
         for msg in messages:
             assert msg in unit.workload_status_message
 


### PR DESCRIPTION
The functional test https://github.com/canonical/hardware-observer-operator/actions/runs/9614238924/job/26519462764
are failing due to a mismatch in grafana agent message format. This may due to the recent update of grafana-agent version used for github action. Updated functional test to match the new format.