### PR TITLE
Update line filter for ipmiseld in BMC dashboard

### DIFF
--- a/src/grafana_dashboards/BMC.json
+++ b/src/grafana_dashboards/BMC.json
@@ -250,7 +250,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "{instance=\"$instance_var\"} |= `ipmiseld` | pattern `<raw>\"<_>\"` | regexp `(?P<log_time>\\w+\\s*\\d{1,2} \\d+:\\d+:\\d+) (?P<host>.+?) (?P<pid>\\S+): (SEL System Event: (?P<bmc_time>\\w{3}-\\d{2}-\\d{4}, \\d{2}:\\d{2}:\\d{2}), )?(?P<msg>.*)` | line_format `{{ if .bmc_time }}{{ .bmc_time | replace \"-\" \" \" }}{{ else }}{{ .log_time }}{{ end }}`",
+          "expr": "{instance=\"$instance_var\"} |~ \"ipmiseld\\\\[\\\\d+\\\\]\" | pattern `<raw>\"<_>\"` | regexp `(?P<log_time>\\w+\\s*\\d{1,2} \\d+:\\d+:\\d+) (?P<host>.+?) (?P<pid>\\S+): (SEL System Event: (?P<bmc_time>\\w{3}-\\d{2}-\\d{4}, \\d{2}:\\d{2}:\\d{2}), )?(?P<msg>.*)` | line_format `{{ if .bmc_time }}{{ .bmc_time | replace \"-\" \" \" }}{{ else }}{{ .log_time }}{{ end }}`",
           "queryType": "range",
           "refId": "A"
         }


### PR DESCRIPTION
Update line filter to use regex to match ipmiseld pid, the updated dashboard would no longer capture redundant logs:
Before:
![image](https://github.com/canonical/hardware-observer-operator/assets/29085124/f58a5a57-6525-4778-b8bf-8b5e17380a3b)

After:
![image](https://github.com/canonical/hardware-observer-operator/assets/29085124/a39c2a40-658f-401e-833c-94ddbad443e0)


Closes https://github.com/canonical/hardware-observer-operator/issues/269