### PR TITLE
fix: redfish validation

### DIFF
--- a/src/service.py
+++ b/src/service.py
@@ -398,10 +398,10 @@ class HardwareExporter(BaseExporter):
             return None
 
         # Skip redfish validation if either username/password is empty.
-        if redfish_conn_params and not (
+        if not (
             redfish_conn_params.get("username", "") and redfish_conn_params.get("password", "")
         ):
-            logger.warning("Empty redfish certificate, skip validation.")
+            logger.warning("Empty redfish username/password, skip validation.")
             return False
 
         redfish_obj = None

--- a/src/service.py
+++ b/src/service.py
@@ -397,6 +397,13 @@ class HardwareExporter(BaseExporter):
         if not redfish_conn_params:
             return None
 
+        # Skip redfish validation if either username/password is empty.
+        if redfish_conn_params and not (
+            redfish_conn_params.get("username", "") and redfish_conn_params.get("password", "")
+        ):
+            logger.warning("Empty redfish certificate, skip validation.")
+            return False
+
         redfish_obj = None
         try:
             redfish_obj = redfish_client(

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -563,6 +563,39 @@ class TestHardwareExporter(unittest.TestCase):
         self.assertFalse(result)
         mock_redfish_client.return_value.login.assert_not_called()
 
+    @parameterized.expand(
+        [
+            (
+                "missing username",
+                {
+                    "host": "hosta",
+                    "username": "",
+                    "password": "passwordc",
+                    "timeout": "timeoutd",
+                },
+            ),
+            (
+                "missing username",
+                {
+                    "host": "hosta",
+                    "username": "usernameb",
+                    "password": "",
+                    "timeout": "timeoutd",
+                },
+            ),
+        ]
+    )
+    @mock.patch("service.redfish_client")
+    def test_redfish_conn_params_valid_failed_missing_credentials(
+        self,
+        _,
+        redfish_conn_params,
+        mock_redfish_client,
+    ):
+        result = self.exporter.redfish_conn_params_valid(redfish_conn_params)
+        self.assertEqual(result, False)
+        mock_redfish_client.assert_not_called()
+
     def test_hw_tools(self):
         self.assertEqual(
             self.exporter.hw_tools(),

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -575,7 +575,7 @@ class TestHardwareExporter(unittest.TestCase):
                 },
             ),
             (
-                "missing username",
+                "missing password",
                 {
                     "host": "hosta",
                     "username": "usernameb",


### PR DESCRIPTION
Skip redfish validation if either username or password is missing
fix: #270