### PR TITLE
Fix integration test

### DIFF
--- a/tests/integration/test_cos_integration.py
+++ b/tests/integration/test_cos_integration.py
@@ -44,9 +44,7 @@ async def test_alerts(ops_test: OpsTest, lxd_model, k8s_model):
     result_json = stdout.split("proxied-endpoints: ")[1].strip().strip("'")
     address_info = json.loads(result_json)
     traefik_url = address_info.get("traefik").get("url")
-    prometheus_alerts_endpoint = (
-        f"{traefik_url}/{model_name}-prometheus-0/api/v1/alerts"
-    )
+    prometheus_alerts_endpoint = f"{traefik_url}/{model_name}-prometheus-0/api/v1/alerts"
 
     cmd = ["curl", prometheus_alerts_endpoint]
 

--- a/tests/integration/test_cos_integration.py
+++ b/tests/integration/test_cos_integration.py
@@ -38,10 +38,11 @@ async def test_alerts(ops_test: OpsTest, lxd_model, k8s_model):
 
     model_name = ops_test.model_name
 
-    model_status = await k8s_model.get_status()
-    traefik_ip = model_status["applications"]["traefik"].public_address
-
-    prometheus_alerts_endpoint = f"http://{traefik_ip}/{model_name}-prometheus-0/api/v1/alerts"
+    returncode, stdout, stderr = await ops_test.run("juju", "run", "traefik/0", "show-proxied-endpoints")
+    result_json = stdout.split('proxied-endpoints: ')[1].strip().strip('\'')
+    internal_address_info = json.loads(result_json)
+    prometheus_internal_url = internal_address_info.get("traefik").get("url")
+    prometheus_alerts_endpoint = f"{prometheus_internal_url}/{model_name}-prometheus-0/api/v1/alerts"
 
     cmd = ["curl", prometheus_alerts_endpoint]
 

--- a/tests/integration/test_cos_integration.py
+++ b/tests/integration/test_cos_integration.py
@@ -36,6 +36,7 @@ async def test_alerts(ops_test: OpsTest, lxd_model, k8s_model):
     await _disable_hardware_exporter(ops_test, lxd_model)
     await _export_mock_metrics(lxd_model)
 
+    # Run juju action to get the ip address that traefik is configured to serve on
     returncode, stdout, stderr = await ops_test.run(
         "juju",
         "run",

--- a/tests/integration/test_cos_integration.py
+++ b/tests/integration/test_cos_integration.py
@@ -38,11 +38,15 @@ async def test_alerts(ops_test: OpsTest, lxd_model, k8s_model):
 
     model_name = ops_test.model_name
 
-    returncode, stdout, stderr = await ops_test.run("juju", "run", "traefik/0", "show-proxied-endpoints")
-    result_json = stdout.split('proxied-endpoints: ')[1].strip().strip('\'')
+    returncode, stdout, stderr = await ops_test.run(
+        "juju", "run", "traefik/0", "show-proxied-endpoints"
+    )
+    result_json = stdout.split("proxied-endpoints: ")[1].strip().strip("'")
     internal_address_info = json.loads(result_json)
     prometheus_internal_url = internal_address_info.get("traefik").get("url")
-    prometheus_alerts_endpoint = f"{prometheus_internal_url}/{model_name}-prometheus-0/api/v1/alerts"
+    prometheus_alerts_endpoint = (
+        f"{prometheus_internal_url}/{model_name}-prometheus-0/api/v1/alerts"
+    )
 
     cmd = ["curl", prometheus_alerts_endpoint]
 

--- a/tests/integration/test_cos_integration.py
+++ b/tests/integration/test_cos_integration.py
@@ -42,10 +42,10 @@ async def test_alerts(ops_test: OpsTest, lxd_model, k8s_model):
         "juju", "run", "traefik/0", "show-proxied-endpoints"
     )
     result_json = stdout.split("proxied-endpoints: ")[1].strip().strip("'")
-    internal_address_info = json.loads(result_json)
-    prometheus_internal_url = internal_address_info.get("traefik").get("url")
+    address_info = json.loads(result_json)
+    traefik_url = address_info.get("traefik").get("url")
     prometheus_alerts_endpoint = (
-        f"{prometheus_internal_url}/{model_name}-prometheus-0/api/v1/alerts"
+        f"{traefik_url}/{model_name}-prometheus-0/api/v1/alerts"
     )
 
     cmd = ["curl", prometheus_alerts_endpoint]


### PR DESCRIPTION
COS Integration tests have been failing due to accessing traefik endpoint by public ip address, fix the test to use ip address that traefik is configured to serve on.
[Test](https://github.com/canonical/hardware-observer-operator/actions/runs/9948214345/job/27482345136) passed.
Fixes: https://github.com/canonical/hardware-observer-operator/issues/266