### PR TITLE
Clean up logic in `_on_config_changed` event

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -233,20 +233,21 @@ class HardwareObserverCharm(ops.CharmBase):
             event.defer()
             return
 
-        success, message = self.validate_configs()
-        if not success:
-            self.model.unit.status = BlockedStatus(message)
-            return
-        for exporter in self.exporters:
-            success = exporter.render_config()
-            if success:
-                exporter.restart()
-            else:
-                message = (
-                    f"Failed to configure {exporter.exporter_name}, "
-                    "please check if the server is healthy."
-                )
+        if self.cos_agent_related:
+            success, message = self.validate_configs()
+            if not success:
                 self.model.unit.status = BlockedStatus(message)
+                return
+            for exporter in self.exporters:
+                success = exporter.render_config()
+                if success:
+                    exporter.restart()
+                else:
+                    message = (
+                        f"Failed to configure {exporter.exporter_name}, "
+                        "please check if the server is healthy."
+                    )
+                    self.model.unit.status = BlockedStatus(message)
 
         self._on_update_status(event)
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -492,6 +492,14 @@ class TestCharm(unittest.TestCase):
                 [(True, ""), (True, "")],
             ),
             (
+                "No cos_agent_related",
+                True,
+                False,
+                (True, ""),
+                [mock.MagicMock(), mock.MagicMock()],
+                [(True, ""), (True, "")],
+            ),
+            (
                 "invalid config",
                 True,
                 True,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -552,6 +552,8 @@ class TestCharm(unittest.TestCase):
 
             if not resource_installed:
                 mock_logger.info.assert_called()
+                self.harness.charm.validate_configs.assert_not_called()
+                self.harness.charm._on_update_status.assert_not_called()
             else:
                 if not cos_agent_related:
                     self.harness.charm.validate_configs.assert_not_called()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -545,6 +545,10 @@ class TestCharm(unittest.TestCase):
             if not resource_installed:
                 mock_logger.info.assert_called()
             else:
+                if not cos_agent_related:
+                    self.harness.charm.validate_configs.assert_not_called()
+                    self.harness.charm._on_update_status.assert_called()
+                    return
                 if not validate_configs_return[0]:
                     self.assertEqual(self.harness.charm.unit.status, BlockedStatus("invalid msg"))
                     self.harness.charm.exporters[0].render_config.assert_not_called()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -552,29 +552,32 @@ class TestCharm(unittest.TestCase):
 
             if not resource_installed:
                 mock_logger.info.assert_called()
-            if not cos_agent_related:
-                self.harness.charm.validate_configs.assert_not_called()
+            else:
+                if not cos_agent_related:
+                    self.harness.charm.validate_configs.assert_called()
+                    self.harness.charm._on_update_status.assert_called()
+                    return
+                if not validate_configs_return[0]:
+                    self.assertEqual(self.harness.charm.unit.status, BlockedStatus("invalid msg"))
+                    self.harness.charm.exporters[0].render_config.assert_not_called()
+                    return
+                if not all(mock_exporters_render_config_returns):
+                    for mock_exporter, render_config_return in zip(
+                        mock_exporters,
+                        mock_exporters_render_config_returns,
+                    ):
+                        if render_config_return:
+                            mock_exporter.restart.assert_called()
+                        else:
+                            message = (
+                                f"Failed to configure {mock_exporter.exporter_name}, "
+                                f"please check if the server is healthy."
+                            )
+                            self.assertEqual(
+                                self.harness.charm.unit.status, BlockedStatus(message)
+                            )
+                    self.harness.charm._on_update_status.assert_called()
                 self.harness.charm._on_update_status.assert_called()
-                return
-            if not validate_configs_return[0]:
-                self.assertEqual(self.harness.charm.unit.status, BlockedStatus("invalid msg"))
-                self.harness.charm.exporters[0].render_config.assert_not_called()
-                return
-            if not all(mock_exporters_render_config_returns):
-                for mock_exporter, render_config_return in zip(
-                    mock_exporters,
-                    mock_exporters_render_config_returns,
-                ):
-                    if render_config_return:
-                        mock_exporter.restart.assert_called()
-                    else:
-                        message = (
-                            f"Failed to configure {mock_exporter.exporter_name}, "
-                            f"please check if the server is healthy."
-                        )
-                        self.assertEqual(self.harness.charm.unit.status, BlockedStatus(message))
-                self.harness.charm._on_update_status.assert_called()
-            self.harness.charm._on_update_status.assert_called()
 
     def test_config_changed_update_alert_rules(self):
         """Test config changed will update alert rule."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -492,14 +492,6 @@ class TestCharm(unittest.TestCase):
                 [(True, ""), (True, "")],
             ),
             (
-                "No cos_agent_related",
-                True,
-                False,
-                (True, ""),
-                [mock.MagicMock(), mock.MagicMock()],
-                [(True, ""), (True, "")],
-            ),
-            (
                 "invalid config",
                 True,
                 True,
@@ -553,10 +545,6 @@ class TestCharm(unittest.TestCase):
             if not resource_installed:
                 mock_logger.info.assert_called()
             else:
-                if not cos_agent_related:
-                    self.harness.charm.validate_configs.assert_called()
-                    self.harness.charm._on_update_status.assert_called()
-                    return
                 if not validate_configs_return[0]:
                     self.assertEqual(self.harness.charm.unit.status, BlockedStatus("invalid msg"))
                     self.harness.charm.exporters[0].render_config.assert_not_called()


### PR DESCRIPTION
Fixes: https://github.com/canonical/hardware-observer-operator/issues/284, https://github.com/canonical/hardware-observer-operator/issues/215

Issue https://github.com/canonical/hardware-observer-operator/issues/284 arises because there's no return statement following the defer() in the _on_config_changed event. When hardware-observer is deployed without a resource, the _on_config_changed event triggers, but no exporter gets installed. In the absence of a return statement, the function continues execution and may attempt to restart an exporter that hasn't been installed, which lead to a crash.

For the second fix mentioned in https://github.com/canonical/hardware-observer-operator/issues/215, the configuration is not rendered if the cos-agent relation is not provided. Considering this is a life cycle issue, I suggest we do not change it here and leave it to be modified in the next life cycle change.