### PR TITLE
Add config option to disable redfish

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -44,3 +44,8 @@ options:
     default: ""
     description: |
       BMC password to be used by the redfish collector.
+  redfish-enable:
+    type: boolean
+    default: true
+    description: |
+      Boolean flag to enable or disable the Redfish collector. By default the Redfish is enabled.

--- a/config.yaml
+++ b/config.yaml
@@ -44,8 +44,8 @@ options:
     default: ""
     description: |
       BMC password to be used by the redfish collector.
-  redfish-enable:
+  redfish-disable:
     type: boolean
-    default: true
+    default: false
     description: |
-      Boolean flag to enable or disable the Redfish collector. By default the Redfish is enabled.
+      Boolean flag to disable the Redfish collector. Defaults to enabled (if redfish is available).

--- a/config.yaml
+++ b/config.yaml
@@ -48,4 +48,5 @@ options:
     type: boolean
     default: false
     description: |
-      Boolean flag to disable the Redfish collector. Defaults to enabled (if redfish is available).
+      Boolean flag to force disabling the Redfish collector. The collector will normally be run if
+      Redfish support is detected on the unit.

--- a/src/charm.py
+++ b/src/charm.py
@@ -88,7 +88,7 @@ class HardwareObserverCharm(ops.CharmBase):
         """Get the current hardware tools from stored or from machine if not present.
 
         This function stores the current hardware tools as strings because StoredState cannot store
-        arbitrary objects. HWTool object can however be re-instantiated from tool names.
+        arbitrary objects. HWTool objects can however be re-instantiated from tool names.
         """
         if not self._stored.stored_tools:  # type: ignore[truthy-function]
             available_tools = detect_available_tools()  # type: ignore[unreachable]

--- a/src/charm.py
+++ b/src/charm.py
@@ -93,9 +93,7 @@ class HardwareObserverCharm(ops.CharmBase):
         if not self._stored.stored_tools:  # type: ignore[truthy-function]
             available_tools = detect_available_tools()  # type: ignore[unreachable]
             self._stored.stored_tools = {tool.value for tool in available_tools}
-        return {
-            HWTool(value) for value in self._stored.stored_tools  # type: ignore[attr-defined]
-        }
+        return {HWTool(value) for value in self._stored.stored_tools}  # type: ignore[attr-defined]
 
     def _on_redetect_hardware(self, event: ops.ActionEvent) -> None:
         """Redetect available hardware tools and option to rerun the install hook."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -12,7 +12,7 @@ from charms.grafana_agent.v0.cos_agent import COSAgentProvider
 from ops.framework import EventBase, StoredState
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
 
-from hw_tools import HWTool, HWToolHelper, get_available_hw_tools
+from hw_tools import HWTool, HWToolHelper, detect_available_tools
 from service import BaseExporter, ExporterError, HardwareExporter, SmartCtlExporter
 
 logger = logging.getLogger(__name__)
@@ -47,7 +47,7 @@ class HardwareObserverCharm(ops.CharmBase):
             # resource_installed is a flag that tracks the installation state for
             # the juju resources and also the different exporters
             resource_installed=False,
-            available_hw_tools=set(),
+            current_tools=set(),
         )
 
         self.framework.observe(self.on.config_changed, self._on_config_changed)
@@ -69,59 +69,57 @@ class HardwareObserverCharm(ops.CharmBase):
     def exporters(self) -> List[BaseExporter]:
         """Return list of exporters based on detected hardware."""
         exporters: List[BaseExporter] = []
-        available_hw_tools = self.get_available_hw_tools_stored()
-        if available_hw_tools & HardwareExporter.hw_tools():
+        current_tools = self.get_current_tools()
+        if current_tools & HardwareExporter.hw_tools():
             exporters.append(
                 HardwareExporter(
                     self.charm_dir,
                     self.model.config,
-                    available_hw_tools,
+                    current_tools,
                 )
             )
 
-        if available_hw_tools & SmartCtlExporter.hw_tools():
+        if current_tools & SmartCtlExporter.hw_tools():
             exporters.append(SmartCtlExporter(self.charm_dir, self.model.config))
 
         return exporters
 
-    def get_available_hw_tools_stored(self) -> Set[HWTool]:
-        """Get the available hardware tools from stored or from machine if not present.
+    def get_current_tools(self) -> Set[HWTool]:
+        """Get the current hardware tools from stored or from machine if not present.
 
-        This function store the available hardware tools as string because HWTool object is not
+        This function store the current hardware tools as string because HWTool object is not
         accepted on Ops framework. However, to return the values it uses HWTool objects.
         """
-        if not self._stored.available_hw_tools:  # type: ignore[truthy-function]
-            available_hw_tools = get_available_hw_tools()  # type: ignore[unreachable]
-            self._stored.available_hw_tools = {tool.value for tool in available_hw_tools}
+        if not self._stored.current_tools:  # type: ignore[truthy-function]
+            current_tools = detect_available_tools()  # type: ignore[unreachable]
+            self._stored.current_tools = {tool.value for tool in current_tools}
         return {
-            HWTool(value)
-            for value in self._stored.available_hw_tools  # type: ignore[attr-defined]
+            HWTool(value) for value in self._stored.current_tools  # type: ignore[attr-defined]
         }
 
     def _on_redetect_hardware(self, event: ops.ActionEvent) -> None:
         """Redetect available hardware tools and option to rerun the install hook."""
-        stored_available_hw_tools = self.get_available_hw_tools_stored()
-        available_hw_tools = get_available_hw_tools()
+        current_tools = self.get_current_tools()
+        available_tools = detect_available_tools()
 
-        hw_change_detected = stored_available_hw_tools != available_hw_tools
+        hw_change_detected = current_tools != available_tools
 
-        ordered_available_hw_tools = ",".join(
-            map(lambda member: member.value, sorted(available_hw_tools))
+        sorted_current_tools = ",".join(map(lambda member: member.value, sorted(current_tools)))
+        sorted_available_tools = ",".join(
+            map(lambda member: member.value, sorted(available_tools))
         )
 
         if event.params["apply"] and hw_change_detected:
             # Update the value in local Store
-            self._stored.available_hw_tools = available_hw_tools
-            event.log(f"Run install hook with enable tools: {ordered_available_hw_tools}")
+            self._stored.current_tools = available_tools
+            event.log(f"Run install hook with enable tools: {sorted_available_tools}")
             self._on_install_or_upgrade(event=event)
 
         result = {
             "hardware-change-detected": hw_change_detected,
-            "current-hardware-tools": ",".join(
-                map(lambda member: member.value, sorted(stored_available_hw_tools))
-            ),
+            "current-hardware-tools": sorted_current_tools,
             "update-hardware-tools": bool(event.params["apply"] and hw_change_detected),
-            "detected-hardware-tools": ordered_available_hw_tools if hw_change_detected else "",
+            "detected-hardware-tools": sorted_available_tools if hw_change_detected else "",
         }
 
         event.set_results(result)
@@ -130,15 +128,13 @@ class HardwareObserverCharm(ops.CharmBase):
         """Install or upgrade charm."""
         self.model.unit.status = MaintenanceStatus("Installing resources...")
 
-        available_hw_tools = self.get_available_hw_tools_stored()
+        current_tools = self.get_current_tools()
 
         msg: str
         resource_installed: bool
 
         # Install hw tools
-        resource_installed, msg = self.hw_tool_helper.install(
-            self.model.resources, available_hw_tools
-        )
+        resource_installed, msg = self.hw_tool_helper.install(self.model.resources, current_tools)
 
         self._stored.resource_installed = resource_installed
         if not resource_installed:
@@ -165,7 +161,7 @@ class HardwareObserverCharm(ops.CharmBase):
         # Remove binary tool
         self.hw_tool_helper.remove(
             self.model.resources,
-            self.get_available_hw_tools_stored(),
+            self.get_current_tools(),
         )
         self._stored.resource_installed = False
 
@@ -190,9 +186,7 @@ class HardwareObserverCharm(ops.CharmBase):
                 self.model.unit.status = BlockedStatus(config_valid_message)
                 return
 
-        hw_tool_ok, error_msg = self.hw_tool_helper.check_installed(
-            self.get_available_hw_tools_stored()
-        )
+        hw_tool_ok, error_msg = self.hw_tool_helper.check_installed(self.get_current_tools())
         if not hw_tool_ok:
             self.model.unit.status = BlockedStatus(error_msg)
             return

--- a/src/hw_tools.py
+++ b/src/hw_tools.py
@@ -601,8 +601,8 @@ def disk_hw_verifier() -> Set[HWTool]:
     return {HWTool.SMARTCTL} if lshw(class_filter="disk") else set()
 
 
-def get_available_hw_tools() -> Set[HWTool]:
-    """Return HWTool available after checking the hardware."""
+def detect_available_tools() -> Set[HWTool]:
+    """Return HWTool detected after checking the hardware."""
     return raid_hw_verifier() | bmc_hw_verifier() | disk_hw_verifier()
 
 

--- a/src/service.py
+++ b/src/service.py
@@ -388,7 +388,7 @@ class HardwareExporter(BaseExporter):
         if not valid:
             return valid, msg
 
-        if self.redfish_conn_params_valid() is False:
+        if HWTool.REDFISH in self.enabled_tools and self.redfish_conn_params_valid() is False:
             logger.error("Invalid redfish credentials.")
             return False, "Invalid config: 'redfish-username' or 'redfish-password'"
 
@@ -400,9 +400,6 @@ class HardwareExporter(BaseExporter):
         Verifies the connection parameters if redfish is enabled. If the redfish connection
         parameters are valid, it returns True; if not valid, it returns False.
         """
-        if HWTool.REDFISH not in self.enabled_tools:
-            return True
-
         if not (
             self.redfish_conn_params.get("username", "")
             and self.redfish_conn_params.get("password", "")

--- a/src/service.py
+++ b/src/service.py
@@ -384,7 +384,6 @@ class HardwareExporter(BaseExporter):
 
     def validate_exporter_configs(self) -> Tuple[bool, str]:
         """Validate the static and runtime config options for the exporter."""
-
         valid, msg = super().validate_exporter_configs()
         if not valid:
             return valid, msg

--- a/src/service.py
+++ b/src/service.py
@@ -338,16 +338,15 @@ class HardwareExporter(BaseExporter):
         self.config_template = self.environment.get_template(self.settings.config_template)
         self.exporter_config_path = self.settings.config_path
         self.port = int(config["hardware-exporter-port"])
-
+        self.config = config
         self.available_hw_tool = available_hw_tools
-
-        self.redfish_conn_params = self.get_redfish_conn_params(config)
         self.collect_timeout = int(config["collect-timeout"])
 
     def _render_config_content(self) -> str:
         """Render and install exporter config file."""
+        redfish_conn_params = self.redfish_conn_params
         collectors = set()
-        for tool in self.available_hw_tool:
+        for tool in self.enabled_tools:
             collector = HARDWARE_EXPORTER_COLLECTOR_MAPPING.get(tool)
             if collector is not None:
                 collectors.add(collector)
@@ -356,13 +355,24 @@ class HardwareExporter(BaseExporter):
             LEVEL=self.log_level,
             COLLECT_TIMEOUT=self.collect_timeout,
             COLLECTORS=collectors,
-            REDFISH_ENABLE=self.redfish_conn_params,
-            REDFISH_HOST=self.redfish_conn_params.get("host", ""),
-            REDFISH_USERNAME=self.redfish_conn_params.get("username", ""),
-            REDFISH_PASSWORD=self.redfish_conn_params.get("password", ""),
-            REDFISH_CLIENT_TIMEOUT=self.redfish_conn_params.get("timeout", ""),
+            REDFISH_ENABLE=self.is_redfish_available_and_enabled,
+            REDFISH_HOST=redfish_conn_params.get("host", ""),
+            REDFISH_USERNAME=redfish_conn_params.get("username", ""),
+            REDFISH_PASSWORD=redfish_conn_params.get("password", ""),
+            REDFISH_CLIENT_TIMEOUT=redfish_conn_params.get("timeout", ""),
         )
         return content
+
+    @property
+    def enabled_tools(self) -> Set[HWTool]:
+        """Get the enabled hardware tools.
+
+        Tools that are available, but disabled should not be used on prometheus hardware exporter.
+        """
+        available_tools = self.available_hw_tool.copy()
+        if not self.is_redfish_available_and_enabled:
+            available_tools.discard(HWTool.REDFISH)
+        return available_tools
 
     def render_service(self) -> bool:
         """Render required files for service."""
@@ -380,15 +390,13 @@ class HardwareExporter(BaseExporter):
         if not valid:
             return valid, msg
 
-        # Note we need to use `is False` because `None` means redfish is not
-        # available.
-        if self.redfish_conn_params_valid(self.redfish_conn_params) is False:
+        if self.redfish_conn_params_valid() is False:
             logger.error("Invalid redfish credentials.")
             return False, "Invalid config: 'redfish-username' or 'redfish-password'"
 
         return True, "Exporter config is valid."
 
-    def redfish_conn_params_valid(self, redfish_conn_params: Dict[str, str]) -> Optional[bool]:
+    def redfish_conn_params_valid(self) -> bool:
         """Check if redfish connections parameters is valid or not.
 
         If the redfish connection params is not available this property returns
@@ -396,9 +404,7 @@ class HardwareExporter(BaseExporter):
         connection parameters are valid, it returns True; if not valid, it
         returns False.
         """
-        if not redfish_conn_params:
-            return None
-
+        redfish_conn_params = self.redfish_conn_params
         # Skip redfish validation if either username/password is empty.
         if not (
             redfish_conn_params.get("username", "") and redfish_conn_params.get("password", "")
@@ -433,16 +439,14 @@ class HardwareExporter(BaseExporter):
 
         return result
 
-    def get_redfish_conn_params(self, config: ConfigData) -> Dict[str, Any]:
-        """Get redfish connection parameters if redfish is available."""
-        if HWTool.REDFISH not in self.available_hw_tool:
-            logger.warning("Redfish unavailable, disregarding redfish config options...")
-            return {}
+    @property
+    def redfish_conn_params(self) -> Dict[str, Any]:
+        """Get redfish connection parameters."""
         return {
             "host": f"https://{get_bmc_address()}",
-            "username": config["redfish-username"],
-            "password": config["redfish-password"],
-            "timeout": config["collect-timeout"],
+            "username": self.config["redfish-username"],
+            "password": self.config["redfish-password"],
+            "timeout": self.config["collect-timeout"],
         }
 
     @staticmethod
@@ -459,3 +463,8 @@ class HardwareExporter(BaseExporter):
             HWTool.IPMI_SENSOR,
             HWTool.REDFISH,
         }
+
+    @property
+    def is_redfish_available_and_enabled(self) -> bool:
+        """Check if redfish is available in the hardware and if the user wants to enable it."""
+        return bool(HWTool.REDFISH in self.available_hw_tool and self.config["redfish-enable"])

--- a/src/service.py
+++ b/src/service.py
@@ -329,9 +329,7 @@ class HardwareExporter(BaseExporter):
 
     required_config: bool = True
 
-    def __init__(
-        self, charm_dir: Path, config: ConfigData, available_hw_tools: Set[HWTool]
-    ) -> None:
+    def __init__(self, charm_dir: Path, config: ConfigData, available_tools: Set[HWTool]) -> None:
         """Initialize the Hardware Exporter class."""
         super().__init__(charm_dir, config, HARDWARE_EXPORTER_SETTINGS)
 
@@ -339,7 +337,7 @@ class HardwareExporter(BaseExporter):
         self.exporter_config_path = self.settings.config_path
         self.port = int(config["hardware-exporter-port"])
         self.config = config
-        self.available_hw_tool = available_hw_tools
+        self.available_tools = available_tools
         self.collect_timeout = int(config["collect-timeout"])
         self.bmc_address = get_bmc_address()
 
@@ -369,10 +367,10 @@ class HardwareExporter(BaseExporter):
 
         Tools that are available, but disabled should not be used on prometheus hardware exporter.
         """
-        available_tools = self.available_hw_tool.copy()
+        enabled_tools = self.available_tools.copy()
         if not self.is_redfish_available_and_enabled:
-            available_tools.discard(HWTool.REDFISH)
-        return available_tools
+            enabled_tools.discard(HWTool.REDFISH)
+        return enabled_tools
 
     def render_service(self) -> bool:
         """Render required files for service."""
@@ -464,4 +462,4 @@ class HardwareExporter(BaseExporter):
     @property
     def is_redfish_available_and_enabled(self) -> bool:
         """Check if redfish is available in the hardware and if the user wants to enable it."""
-        return bool(HWTool.REDFISH in self.available_hw_tool and self.config["redfish-enable"])
+        return bool(HWTool.REDFISH in self.available_tools and self.config["redfish-enable"])

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -23,16 +23,16 @@ class TestCharm(unittest.TestCase):
         self.harness = ops.testing.Harness(HardwareObserverCharm)
         self.addCleanup(self.harness.cleanup)
 
-        get_available_hw_tools_patcher = mock.patch.object(charm, "get_available_hw_tools")
-        self.mock_get_available_hw_tools = get_available_hw_tools_patcher.start()
-        self.mock_get_available_hw_tools.return_value = {
+        detect_available_tools_patcher = mock.patch.object(charm, "detect_available_tools")
+        self.mock_detect_available_tools = detect_available_tools_patcher.start()
+        self.mock_detect_available_tools.return_value = {
             HWTool.IPMI_SENSOR,
             HWTool.IPMI_SEL,
             HWTool.IPMI_DCMI,
             HWTool.REDFISH,
         }
 
-        self.addCleanup(get_available_hw_tools_patcher.stop)
+        self.addCleanup(detect_available_tools_patcher.stop)
 
         requests_patcher = mock.patch("hw_tools.requests")
         requests_patcher.start()
@@ -63,14 +63,14 @@ class TestCharm(unittest.TestCase):
     )
     @mock.patch("charm.SmartCtlExporter.__init__", return_value=None)
     @mock.patch("charm.HardwareExporter.__init__", return_value=None)
-    def test_exporters(self, _, enable_tools, expect, mock_hw_exporter, mock_smart_exporter):
+    def test_exporters(self, _, current_tools, expect, mock_hw_exporter, mock_smart_exporter):
         self.harness.begin()
-        self.harness.charm.get_available_hw_tools_stored = mock.MagicMock()
-        self.harness.charm.get_available_hw_tools_stored.return_value = enable_tools
-        self.harness.charm._stored.available_hw_tools = {tool.value for tool in enable_tools}
+        self.harness.charm.get_current_tools = mock.MagicMock()
+        self.harness.charm.get_current_tools.return_value = current_tools
+        self.harness.charm._stored.current_tools = {tool.value for tool in current_tools}
 
         exporters = self.harness.charm.exporters
-        self.harness.charm.get_available_hw_tools_stored.assert_called()
+        self.harness.charm.get_current_tools.assert_called()
 
         if "hardware-exporter" in expect:
             self.assertTrue(
@@ -79,7 +79,7 @@ class TestCharm(unittest.TestCase):
             mock_hw_exporter.assert_called_with(
                 self.harness.charm.charm_dir,
                 self.harness.charm.model.config,
-                self.harness.charm._stored.available_hw_tools,
+                self.harness.charm._stored.current_tools,
             )
         if "smartctl-exporter" in expect:
             self.assertTrue(
@@ -146,7 +146,7 @@ class TestCharm(unittest.TestCase):
         self,
         _,
         event,
-        hw_tools,
+        current_tools,
         hw_tool_helper_install_return,
         mock_exporters,
         mock_exporter_install_returns,
@@ -160,8 +160,8 @@ class TestCharm(unittest.TestCase):
             self.harness.begin()
             self.harness.charm.hw_tool_helper = mock.MagicMock()
             self.harness.charm.hw_tool_helper.install.return_value = hw_tool_helper_install_return
-            self.harness.charm.get_available_hw_tools_stored = mock.MagicMock()
-            self.harness.charm.get_available_hw_tools_stored.return_value = hw_tools
+            self.harness.charm.get_current_tools = mock.MagicMock()
+            self.harness.charm.get_current_tools.return_value = current_tools
             self.harness.charm._on_update_status = mock.MagicMock()
 
             for mock_exporter, return_val in zip(
@@ -176,7 +176,7 @@ class TestCharm(unittest.TestCase):
 
         self.harness.charm.hw_tool_helper.install.assert_called_with(
             self.harness.charm.model.resources,
-            hw_tools,
+            current_tools,
         )
 
         store_resource = False
@@ -201,8 +201,8 @@ class TestCharm(unittest.TestCase):
             self.harness.begin()
             self.harness.charm.hw_tool_helper = mock.MagicMock()
 
-            self.harness.charm.get_available_hw_tools_stored = mock.MagicMock()
-            self.harness.charm.get_available_hw_tools_stored.return_value = {
+            self.harness.charm.get_current_tools = mock.MagicMock()
+            self.harness.charm.get_current_tools.return_value = {
                 HWTool.IPMI_SENSOR,
                 HWTool.IPMI_SEL,
                 HWTool.SMARTCTL,
@@ -346,7 +346,7 @@ class TestCharm(unittest.TestCase):
             return
 
         self.harness.charm.hw_tool_helper.check_installed.assert_called_with(
-            self.harness.charm.get_available_hw_tools_stored()
+            self.harness.charm.get_current_tools()
         )
         if not hw_tool_check_installed[0]:
             self.assertEqual(
@@ -432,40 +432,38 @@ class TestCharm(unittest.TestCase):
         ]
     )
     @mock.patch(
-        "charm.get_available_hw_tools",
+        "charm.detect_available_tools",
     )
     def test_detect_hardware_action(
         self,
         apply,
-        stored_available_hw_tools,
-        available_hw_tools,
+        current_tools,
+        detected_available_tools,
         expect_output,
-        mock_get_available_hw_tools,
+        mock_detect_available_tools,
     ) -> None:
         """Test action detect-hardware."""
-        mock_get_available_hw_tools.return_value = available_hw_tools
+        mock_detect_available_tools.return_value = detected_available_tools
         self.harness.begin()
         self.harness.charm._on_install_or_upgrade = mock.MagicMock()
-        self.harness.charm._stored.available_hw_tools = [
-            tool.value for tool in stored_available_hw_tools
-        ]
+        self.harness.charm._stored.current_tools = [tool.value for tool in current_tools]
 
         output = self.harness.run_action("redetect-hardware", {"apply": apply})
 
         self.assertEqual(output, expect_output)
 
-        if not stored_available_hw_tools == available_hw_tools:
+        if not current_tools == detected_available_tools:
             if apply:
                 self.assertEqual(
-                    self.harness.charm.get_available_hw_tools_stored(),
-                    available_hw_tools,
+                    self.harness.charm.get_current_tools(),
+                    detected_available_tools,
                 )
                 self.harness.charm._on_install_or_upgrade.assert_called()
             else:
                 self.harness.charm._on_install_or_upgrade.assert_not_called()
                 self.assertEqual(
-                    self.harness.charm.get_available_hw_tools_stored(),
-                    {tool.value for tool in stored_available_hw_tools},
+                    self.harness.charm.get_current_tools(),
+                    {tool.value for tool in current_tools},
                 )
         else:
             self.harness.charm._on_install_or_upgrade.assert_not_called()
@@ -600,8 +598,8 @@ class TestCharm(unittest.TestCase):
             self.harness.charm.hw_tool_helper.install.return_value = (True, "")
             self.harness.charm.hw_tool_helper.check_installed.return_value = (True, "")
 
-            self.harness.charm.get_available_hw_tools_stored = mock.MagicMock()
-            self.harness.charm.get_available_hw_tools_stored.return_value = {
+            self.harness.charm.get_current_tools = mock.MagicMock()
+            self.harness.charm.get_current_tools.return_value = {
                 HWTool.IPMI_SENSOR,
                 HWTool.IPMI_SEL,
                 HWTool.IPMI_DCMI,
@@ -651,8 +649,8 @@ class TestCharm(unittest.TestCase):
             self.harness.charm.hw_tool_helper.install.return_value = (True, "")
             self.harness.charm.hw_tool_helper.check_installed.return_value = (True, "")
 
-            self.harness.charm.get_available_hw_tools_stored = mock.MagicMock()
-            self.harness.charm.get_available_hw_tools_stored.return_value = [
+            self.harness.charm.get_current_tools = mock.MagicMock()
+            self.harness.charm.get_current_tools.return_value = [
                 HWTool.IPMI_SENSOR,
                 HWTool.IPMI_SEL,
                 HWTool.IPMI_DCMI,

--- a/tests/unit/test_hw_tools.py
+++ b/tests/unit/test_hw_tools.py
@@ -45,9 +45,9 @@ from hw_tools import (
     bmc_hw_verifier,
     check_deb_pkg_installed,
     copy_to_snap_common_bin,
+    detect_available_tools,
     disk_hw_verifier,
     file_is_empty,
-    get_available_hw_tools,
     install_deb,
     make_executable,
     raid_hw_verifier,
@@ -860,8 +860,8 @@ class TestSmartCtlExporterStrategy(unittest.TestCase):
 @mock.patch("hw_tools.disk_hw_verifier", return_value={7, 8, 9})
 @mock.patch("hw_tools.bmc_hw_verifier", return_value={1, 2, 3})
 @mock.patch("hw_tools.raid_hw_verifier", return_value={4, 5, 6})
-def test_get_available_hw_tools(mock_raid_verifier, mock_bmc_hw_verifier, mock_disk_hw_verifier):
-    output = get_available_hw_tools()
+def test_detect_available_tools(mock_raid_verifier, mock_bmc_hw_verifier, mock_disk_hw_verifier):
+    output = detect_available_tools()
     mock_raid_verifier.assert_called()
     mock_bmc_hw_verifier.assert_called()
     mock_disk_hw_verifier.assert_called()

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -581,10 +581,8 @@ class TestHardwareExporter(unittest.TestCase):
             "timeout": "timeoutd",
         },
     )
-    @mock.patch("service.HardwareExporter.enabled_tools", new_callable=mock.PropertyMock)
     @mock.patch("service.redfish_client")
-    def test_redfish_conn_params_valid_success(self, mock_redfish_client, mock_enable, _):
-        mock_enable.return_value = {HWTool.REDFISH}
+    def test_redfish_conn_params_valid_success(self, mock_redfish_client, _):
         result = self.exporter.redfish_conn_params_valid()
         self.assertTrue(result)
 
@@ -598,15 +596,6 @@ class TestHardwareExporter(unittest.TestCase):
         mock_redfish_client.return_value.login.assert_called_with(auth="session")
         mock_redfish_client.return_value.logout.assert_called()
 
-    @mock.patch("service.HardwareExporter.enabled_tools", new_callable=mock.PropertyMock)
-    @mock.patch("service.redfish_client")
-    def test_redfish_conn_params_not_enable(self, mock_redfish_client, mock_enable):
-        mock_enable.return_value = {}
-        result = self.exporter.redfish_conn_params_valid()
-
-        self.assertTrue(result)
-        mock_redfish_client.assert_not_called()
-
     @mock.patch(
         "service.HardwareExporter.redfish_conn_params",
         new_callable=mock.PropertyMock,
@@ -617,12 +606,10 @@ class TestHardwareExporter(unittest.TestCase):
             "timeout": "timeoutd",
         },
     )
-    @mock.patch("service.HardwareExporter.enabled_tools", new_callable=mock.PropertyMock)
     @mock.patch("service.redfish_client")
     def test_redfish_conn_params_valid_failed_invalid_credentials_error(
-        self, mock_redfish_client, mock_enable, _
+        self, mock_redfish_client, _
     ):
-        mock_enable.return_value = {HWTool.REDFISH}
         mock_redfish_client.side_effect = InvalidCredentialsError
         result = self.exporter.redfish_conn_params_valid()
 
@@ -646,10 +633,8 @@ class TestHardwareExporter(unittest.TestCase):
             "timeout": "timeoutd",
         },
     )
-    @mock.patch("service.HardwareExporter.enabled_tools", new_callable=mock.PropertyMock)
     @mock.patch("service.redfish_client")
-    def test_redfish_conn_params_valid_failed_exception(self, mock_redfish_client, mock_enable, _):
-        mock_enable.return_value = {HWTool.REDFISH}
+    def test_redfish_conn_params_valid_failed_exception(self, mock_redfish_client, _):
         mock_redfish_client.side_effect = Exception
         result = self.exporter.redfish_conn_params_valid()
 
@@ -698,17 +683,14 @@ class TestHardwareExporter(unittest.TestCase):
         "service.HardwareExporter.redfish_conn_params",
         new_callable=mock.PropertyMock,
     )
-    @mock.patch("service.HardwareExporter.enabled_tools", new_callable=mock.PropertyMock)
     @mock.patch("service.redfish_client")
     def test_redfish_conn_params_valid_failed_missing_credentials(
         self,
         _,
         redfish_conn_params,
         mock_redfish_client,
-        mock_enable,
         mock_redfish_conn_params,
     ):
-        mock_enable.return_value = {HWTool.REDFISH}
         mock_redfish_conn_params.return_value = redfish_conn_params
         result = self.exporter.redfish_conn_params_valid()
         self.assertEqual(result, False)

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -462,8 +462,8 @@ class TestHardwareExporter(unittest.TestCase):
             self.exporter.validate_exporter_configs(),
         )
 
-    def test_render_config_content(self):
-        """Test render config content."""
+    def test_render_config_content_redfish_not_available(self):
+        """Test render config content redfish not available."""
         content = self.exporter._render_config_content()
         content_config = yaml.safe_load(content)
         self.assertEqual(content_config["port"], 10200)
@@ -472,11 +472,99 @@ class TestHardwareExporter(unittest.TestCase):
         self.assertEqual(
             set(content_config["enable_collectors"]), {"collector.mega_raid", "collector.hpe_ssa"}
         )
+        self.assertNotIn("collector.redfish", content_config["enable_collectors"])
+        self.assertNotIn("redfish_username", content_config)
+        self.assertNotIn("redfish_password", content_config)
+        self.assertNotIn("redfish_client_timeout", content_config)
 
-    def test_get_redfish_conn_params_when_redfish_is_available(self):
-        """Test get_redfish_conn_params when Redfish is available."""
-        self.exporter.available_hw_tool = {"redfish"}
-        result = self.exporter.get_redfish_conn_params(self.mock_config)
+    def test_render_config_content_redfish_available_and_disabled(self):
+        """Test render config content redfish is available but disabled."""
+        self.exporter.available_hw_tool = {HWTool.REDFISH, HWTool.IPMI_DCMI}
+        self.exporter.config = {
+            "hardware-exporter-port": 10200,
+            "collect-timeout": 10,
+            "exporter-log-level": "INFO",
+            "redfish-username": "my-user",
+            "redfish-password": "my-pwd",
+            "redfish-enable": False,
+        }
+        content = self.exporter._render_config_content()
+        content_config = yaml.safe_load(content)
+        self.assertEqual(content_config["port"], 10200)
+        self.assertEqual(content_config["level"], "INFO")
+        self.assertEqual(content_config["collect_timeout"], 10)
+        self.assertNotIn("collector.redfish", content_config["enable_collectors"])
+        self.assertNotIn("redfish_username", content_config)
+        self.assertNotIn("redfish_password", content_config)
+        self.assertNotIn("redfish_client_timeout", content_config)
+
+    def test_render_config_content_redfish_available_and_enabled(self):
+        """Test render config content when redfish is available and enabled."""
+        self.exporter.available_hw_tool = {HWTool.REDFISH}
+        self.exporter.config = {
+            "hardware-exporter-port": 10200,
+            "collect-timeout": 10,
+            "exporter-log-level": "INFO",
+            "redfish-username": "my-user",
+            "redfish-password": "my-pwd",
+            "redfish-enable": True,
+        }
+        content = self.exporter._render_config_content()
+        content_config = yaml.safe_load(content)
+        self.assertEqual(content_config["port"], 10200)
+        self.assertEqual(content_config["level"], "INFO")
+        self.assertEqual(content_config["collect_timeout"], 10)
+        self.assertEqual(set(content_config["enable_collectors"]), {"collector.redfish"})
+        self.assertEqual(content_config["redfish_host"], "https://127.0.0.1")
+        self.assertEqual(content_config["redfish_username"], "my-user")
+        self.assertEqual(content_config["redfish_password"], "my-pwd")
+        self.assertEqual(content_config["redfish_client_timeout"], "10")
+
+    @parameterized.expand(
+        [
+            (
+                "Redfish Available and Enabled",
+                True,
+                # keep redfish
+                {HWTool.REDFISH, HWTool.IPMI_SENSOR},
+                {HWTool.REDFISH, HWTool.IPMI_SENSOR},
+            ),
+            (
+                "Redfish not Available",
+                False,
+                {HWTool.IPMI_SENSOR},
+                {HWTool.IPMI_SENSOR},
+            ),
+            (
+                "Redfish Available and disabled",
+                False,
+                {HWTool.REDFISH, HWTool.IPMI_SENSOR},
+                # removed redfish
+                {HWTool.IPMI_SENSOR},
+            ),
+        ]
+    )
+    @mock.patch(
+        "service.HardwareExporter.is_redfish_available_and_enabled",
+        new_callable=mock.PropertyMock,
+    )
+    def test_enabled_tools(
+        self,
+        _,
+        redfish_available_and_enabled,
+        available_hw_tool,
+        expected_result,
+        mock_available_and_enabled,
+    ):
+        """Test that Redfish is removed from available_tools if necessary."""
+        mock_available_and_enabled.return_value = redfish_available_and_enabled
+        self.exporter.available_hw_tool = available_hw_tool
+        self.assertEqual(self.exporter.enabled_tools, expected_result)
+        self.assertEqual(self.exporter.available_hw_tool, available_hw_tool)
+
+    def test_get_redfish_conn_params(self):
+        """Test get_redfish_conn_params."""
+        result = self.exporter.redfish_conn_params
         expected_result = {
             "host": "https://127.0.0.1",
             "username": "",
@@ -485,22 +573,19 @@ class TestHardwareExporter(unittest.TestCase):
         }
         self.assertEqual(result, expected_result)
 
-    def test_get_redfish_conn_params_when_redfish_is_unavailable(self):
-        """Test get_redfish_conn_params when Redfish is not available."""
-        self.exporter.available_hw_tool = {"ssacli"}
-        result = self.exporter.get_redfish_conn_params(self.mock_config)
-        expected_result = {}
-        self.assertEqual(result, expected_result)
-
-    @mock.patch("service.redfish_client")
-    def test_redfish_conn_params_valid_success(self, mock_redfish_client):
-        redfish_conn_params = {
+    @mock.patch(
+        "service.HardwareExporter.redfish_conn_params",
+        new_callable=mock.PropertyMock,
+        return_value={
             "host": "hosta",
             "username": "usernameb",
             "password": "passwordc",
             "timeout": "timeoutd",
-        }
-        result = self.exporter.redfish_conn_params_valid(redfish_conn_params)
+        },
+    )
+    @mock.patch("service.redfish_client")
+    def test_redfish_conn_params_valid_success(self, mock_redfish_client, _):
+        result = self.exporter.redfish_conn_params_valid()
         self.assertTrue(result)
 
         mock_redfish_client.assert_called_with(
@@ -513,24 +598,22 @@ class TestHardwareExporter(unittest.TestCase):
         mock_redfish_client.return_value.login.assert_called_with(auth="session")
         mock_redfish_client.return_value.logout.assert_called()
 
-    @mock.patch("service.redfish_client")
-    def test_redfish_conn_params_valid_miss_redfish_params(self, mock_redfish_client):
-        redfish_conn_params = {}
-        result = self.exporter.redfish_conn_params_valid(redfish_conn_params)
-        self.assertEqual(result, None)
-
-        mock_redfish_client.assert_not_called()
-
-    @mock.patch("service.redfish_client")
-    def test_redfish_conn_params_valid_failed_invalid_credentials_error(self, mock_redfish_client):
-        redfish_conn_params = {
+    @mock.patch(
+        "service.HardwareExporter.redfish_conn_params",
+        new_callable=mock.PropertyMock,
+        return_value={
             "host": "hosta",
             "username": "usernameb",
             "password": "passwordc",
             "timeout": "timeoutd",
-        }
+        },
+    )
+    @mock.patch("service.redfish_client")
+    def test_redfish_conn_params_valid_failed_invalid_credentials_error(
+        self, mock_redfish_client, _
+    ):
         mock_redfish_client.side_effect = InvalidCredentialsError
-        result = self.exporter.redfish_conn_params_valid(redfish_conn_params)
+        result = self.exporter.redfish_conn_params_valid()
 
         mock_redfish_client.assert_called_with(
             base_url="hosta",
@@ -542,16 +625,20 @@ class TestHardwareExporter(unittest.TestCase):
         self.assertFalse(result)
         mock_redfish_client.return_value.login.assert_not_called()
 
-    @mock.patch("service.redfish_client")
-    def test_redfish_conn_params_valid_failed_exception(self, mock_redfish_client):
-        redfish_conn_params = {
+    @mock.patch(
+        "service.HardwareExporter.redfish_conn_params",
+        new_callable=mock.PropertyMock,
+        return_value={
             "host": "hosta",
             "username": "usernameb",
             "password": "passwordc",
             "timeout": "timeoutd",
-        }
+        },
+    )
+    @mock.patch("service.redfish_client")
+    def test_redfish_conn_params_valid_failed_exception(self, mock_redfish_client, _):
         mock_redfish_client.side_effect = Exception
-        result = self.exporter.redfish_conn_params_valid(redfish_conn_params)
+        result = self.exporter.redfish_conn_params_valid()
 
         mock_redfish_client.assert_called_with(
             base_url="hosta",
@@ -583,16 +670,27 @@ class TestHardwareExporter(unittest.TestCase):
                     "timeout": "timeoutd",
                 },
             ),
+            (
+                "missing username and password",
+                {
+                    "host": "hosta",
+                    "username": "",
+                    "password": "",
+                    "timeout": "timeoutd",
+                },
+            ),
         ]
+    )
+    @mock.patch(
+        "service.HardwareExporter.redfish_conn_params",
+        new_callable=mock.PropertyMock,
     )
     @mock.patch("service.redfish_client")
     def test_redfish_conn_params_valid_failed_missing_credentials(
-        self,
-        _,
-        redfish_conn_params,
-        mock_redfish_client,
+        self, _, redfish_conn_params, mock_redfish_client, mock_redfish_conn_params
     ):
-        result = self.exporter.redfish_conn_params_valid(redfish_conn_params)
+        mock_redfish_conn_params.return_value = redfish_conn_params
+        result = self.exporter.redfish_conn_params_valid()
         self.assertEqual(result, False)
         mock_redfish_client.assert_not_called()
 
@@ -611,6 +709,19 @@ class TestHardwareExporter(unittest.TestCase):
                 HWTool.REDFISH,
             },
         )
+
+    @parameterized.expand(
+        [
+            ("Available and Enable", {HWTool.REDFISH}, {"redfish-enable": True}, True),
+            ("Available and Disable", {HWTool.REDFISH}, {"redfish-enable": False}, False),
+            ("Not available and Disable", {}, {"redfish-enable": False}, False),
+            ("Not available and Enable", {}, {"redfish-enable": True}, False),
+        ]
+    )
+    def test_is_redfish_available_and_enabled(self, _, available_hw_tool, config, expected_result):
+        self.exporter.available_hw_tool = available_hw_tool
+        self.exporter.config = config
+        self.assertIs(self.exporter.is_redfish_available_and_enabled, expected_result)
 
 
 class TestSmartMetricExporter(unittest.TestCase):

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -414,9 +414,9 @@ class TestHardwareExporter(unittest.TestCase):
             "redfish-username": "",
             "redfish-password": "",
         }
-        self.mock_stored_hw_tool_available = {"storcli", "ssacli"}
+        self.mock_tools_available = {"storcli", "ssacli"}
         self.exporter = service.HardwareExporter(
-            search_path, self.mock_config, self.mock_stored_hw_tool_available
+            search_path, self.mock_config, self.mock_tools_available
         )
 
     def test_render_service(self):
@@ -479,7 +479,7 @@ class TestHardwareExporter(unittest.TestCase):
 
     def test_render_config_content_redfish_available_and_disabled(self):
         """Test render config content redfish is available but disabled."""
-        self.exporter.available_hw_tool = {HWTool.REDFISH, HWTool.IPMI_DCMI}
+        self.exporter.available_tools = {HWTool.REDFISH, HWTool.IPMI_DCMI}
         self.exporter.config = {
             "hardware-exporter-port": 10200,
             "collect-timeout": 10,
@@ -500,7 +500,7 @@ class TestHardwareExporter(unittest.TestCase):
 
     def test_render_config_content_redfish_available_and_enabled(self):
         """Test render config content when redfish is available and enabled."""
-        self.exporter.available_hw_tool = {HWTool.REDFISH}
+        self.exporter.available_tools = {HWTool.REDFISH}
         self.exporter.config = {
             "hardware-exporter-port": 10200,
             "collect-timeout": 10,
@@ -552,15 +552,15 @@ class TestHardwareExporter(unittest.TestCase):
         self,
         _,
         redfish_available_and_enabled,
-        available_hw_tool,
+        available_tools,
         expected_result,
         mock_available_and_enabled,
     ):
         """Test that Redfish is removed from available_tools if necessary."""
         mock_available_and_enabled.return_value = redfish_available_and_enabled
-        self.exporter.available_hw_tool = available_hw_tool
+        self.exporter.available_tools = available_tools
         self.assertEqual(self.exporter.enabled_tools, expected_result)
-        self.assertEqual(self.exporter.available_hw_tool, available_hw_tool)
+        self.assertEqual(self.exporter.available_tools, available_tools)
 
     def test_get_redfish_conn_params(self):
         """Test get_redfish_conn_params."""
@@ -718,8 +718,8 @@ class TestHardwareExporter(unittest.TestCase):
             ("Not available and Enable", {}, {"redfish-enable": True}, False),
         ]
     )
-    def test_is_redfish_available_and_enabled(self, _, available_hw_tool, config, expected_result):
-        self.exporter.available_hw_tool = available_hw_tool
+    def test_is_redfish_available_and_enabled(self, _, available_tools, config, expected_result):
+        self.exporter.available_tools = available_tools
         self.exporter.config = config
         self.assertIs(self.exporter.is_redfish_available_and_enabled, expected_result)
 


### PR DESCRIPTION
- new charm config to disable redfish. With that, even that redfish is detected the user has the option to disable it.
- applied suggestions to change terminology. current_tools mean the ones already stored as cache.
- detected_available_tools run again (not cached) to detect new hardware
- changed redfish_conn_params to be a class property
- created new class property enabled_tools to remove detected tools that are disabled
- removed the possibility of redfish_conn_params_valid return None

Partially-Closes #282