### PR TITLE
Add multi arch support for smartctl

### DIFF
--- a/src/hw_tools.py
+++ b/src/hw_tools.py
@@ -6,6 +6,7 @@ Define strategy for install, remove and verifier for different hardware.
 import io
 import logging
 import os
+import platform
 import shutil
 import stat
 import subprocess
@@ -411,16 +412,34 @@ class SmartCtlStrategy(APTStrategyABC):
         return check_deb_pkg_installed(self.pkg)
 
 
+def get_release_url(base_url: str, releases: Dict[str, str]) -> str:
+    """Determine the appropriate release URL based on the system architecture."""
+    arch = platform.machine()
+    if arch not in releases:
+        raise ValueError(f"Unsupported architecture: {arch}")
+    return base_url + releases[arch]
+
+
 class SmartCtlExporterStrategy(StrategyABC):  # pylint: disable=R0903
     """Install smartctl exporter binary."""
 
     _name = HWTool.SMARTCTL_EXPORTER
 
     _resource_dir = Path("/opt/SmartCtlExporter/")
-    _release = (
-        "https://github.com/prometheus-community/"
-        "smartctl_exporter/releases/download/v0.12.0/smartctl_exporter-0.12.0.linux-amd64.tar.gz"
+
+    _base_url = (
+        "https://github.com/prometheus-community/smartctl_exporter/releases/download/v0.12.0/"
     )
+
+    _releases = {
+        "x86_64": "smartctl_exporter-0.12.0.linux-amd64.tar.gz",
+        "arm64": "smartctl_exporter-0.12.0.linux-arm64.tar.gz",
+        "ppc64le": "smartctl_exporter-0.12.0.linux-ppc64le.tar.gz",
+        "riscv64": "smartctl_exporter-0.12.0.linux-riscv64.tar.gz",
+        "s390x": "smartctl_exporter-0.12.0.linux-s390x.tar.gz",
+    }
+
+    _release = get_release_url(_base_url, _releases)
     _exporter_name = "smartctl_exporter"
     _exporter_path = Path(_resource_dir / "smartctl_exporter")
 

--- a/tests/unit/test_hw_tools.py
+++ b/tests/unit/test_hw_tools.py
@@ -48,6 +48,7 @@ from hw_tools import (
     detect_available_tools,
     disk_hw_verifier,
     file_is_empty,
+    get_release_url,
     install_deb,
     make_executable,
     raid_hw_verifier,
@@ -762,6 +763,24 @@ class TestSmartCtlStrategy(unittest.TestCase):
         strategy.check()
 
         mock_check_deb_method.assert_called_with("smartmontools")
+
+
+@mock.patch("platform.machine")
+def test_get_release_url(mock_machine):
+    base_url = "https://example.com/releases/"
+    releases = {
+        "x86_64": "example-0.1.0.linux-amd64.tar.gz",
+        "arm64": "example-0.1.0.linux-arm64.tar.gz",
+    }
+
+    # Test for unsupported architecture
+    mock_machine.return_value = "unsupported_arch"
+    try:
+        get_release_url(base_url, releases)
+    except ValueError as e:
+        assert str(e) == "Unsupported architecture: unsupported_arch"
+    else:
+        assert False, "ValueError not raised"
 
 
 class TestSmartCtlExporterStrategy(unittest.TestCase):


### PR DESCRIPTION
Add support for arm64|ppc64le|riscv64|s390x
Arch name reference: https://wiki.debian.org/ArchitectureSpecificsMemo?action=recall&rev=219#fndef-28921cada1db0fe0680e9e948d3015a95dafcfbd-21