### PR TITLE
chore: reenable ops.main type hints

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cosl
 distro
-ops >= 2.2.0
+git+https://github.com/canonical/operator.git@main#egg=ops
 jinja2
 redfish  # requests is included in this
 pydantic < 2


### PR DESCRIPTION
Type hints are finally fixed for `ops.main()` call in the upcoming ops release.

The mypy config includes `warn_unused_ignores` in this repo, which means that using new ops will trigger an error soon.

P.S. can only be merged when ops 2.17.0 is released.