### PR TITLE
Added NVDIA GPU detection

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -79,6 +79,7 @@ class HWTool(str, Enum):
     REDFISH = "redfish"
     SMARTCTL = "smartctl"
     SMARTCTL_EXPORTER = "smartctl_exporter"
+    DCGM = "dcgm"
 
 
 TPR_RESOURCES: t.Dict[HWTool, str] = {

--- a/src/hw_tools.py
+++ b/src/hw_tools.py
@@ -601,9 +601,15 @@ def disk_hw_verifier() -> Set[HWTool]:
     return {HWTool.SMARTCTL} if lshw(class_filter="disk") else set()
 
 
+def nvidia_gpu_verifier() -> Set[HWTool]:
+    """Verify if the hardware has NVIDIA gpu."""
+    gpus = lshw(class_filter="display")
+    return {HWTool.DCGM for gpu in gpus if "nvidia" in gpu.get("vendor", "").lower()}
+
+
 def detect_available_tools() -> Set[HWTool]:
     """Return HWTool detected after checking the hardware."""
-    return raid_hw_verifier() | bmc_hw_verifier() | disk_hw_verifier()
+    return raid_hw_verifier() | bmc_hw_verifier() | disk_hw_verifier() | nvidia_gpu_verifier()
 
 
 class HWToolHelper:


### PR DESCRIPTION
- using the already implemented lshw implementation passing the display class to be filtered
- case is detected one or multiple GPU with NVIDIA vendor, DCGM HWTool is added.