### PR TITLE
Add noble support

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -17,6 +17,10 @@ bases:
       architectures: ["amd64"]
     run-on:
       - name: ubuntu
+        channel: "24.04"
+        architectures:
+          - amd64
+      - name: ubuntu
         channel: "22.04"
         architectures:
           - amd64


### PR DESCRIPTION
Note: we cannot add functional tests for noble, because this is a subordinate charm and we don't have any other principle charms that support noble yet.

I did add functional tests for focal; they were missing from CI.