### PR TITLE
Move testing prometheus rules to separate workflow

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -25,21 +25,6 @@ jobs:
       python-version: ${{ matrix.python-version }}
       tox-version: "<4"
   
-  promtool:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-      # prometheus snap comes pre-packaged with promtool
-      - name: Install prometheus snap
-        run: sudo snap install prometheus
-      - name: Check validity of prometheus alert rules
-        run: |
-          promtool check rules src/prometheus_alert_rules/*.yaml
-      - name: Run unit tests for prometheus alert rules 
-        run: |
-          promtool test rules tests/unit/test_alert_rules/*.yaml
-
   func:
     uses: canonical/bootstack-actions/.github/workflows/func.yaml@v2
     needs: [lint-unit, promtool]

--- a/.github/workflows/test_prometheus_rules.yaml
+++ b/.github/workflows/test_prometheus_rules.yaml
@@ -1,0 +1,34 @@
+name: Test prometheus rules
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+    paths-ignore:
+      - "**.md"
+      - "**.rst"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  promtool:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      # prometheus snap includes promtool
+      - name: Install prometheus snap
+        run: sudo snap install prometheus
+
+      - name: Check validity of prometheus alert rules
+        run: |
+          promtool check rules src/prometheus_alert_rules/*.yaml
+
+      - name: Run unit tests for prometheus alert rules
+        run: |
+          promtool test rules tests/unit/test_alert_rules/*.yaml


### PR DESCRIPTION
This is so we can update the check.yaml workflow
to the latest template from automation.