### PR TITLE
Flake8 is pinned on version < 5 without apperently reasons

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
 coverage
-flake8 < 5
+flake8
 pre-commit
 parameterized


### PR DESCRIPTION
This is breaking to run lint on python 3.12 now that I'm on Noble.