### PR TITLE
Fix write_to_file function

### DIFF
--- a/src/service.py
+++ b/src/service.py
@@ -278,6 +278,7 @@ class RenderableExporter(BaseExporter):
 
 def write_to_file(path: Path, content: str, mode: Optional[int] = None) -> bool:
     """Write to file with provided content.
+
     It's important to first set the permissions to then write the content because it might have
     sensitive information like password.
     """

--- a/src/service.py
+++ b/src/service.py
@@ -277,21 +277,23 @@ class RenderableExporter(BaseExporter):
 
 
 def write_to_file(path: Path, content: str, mode: Optional[int] = None) -> bool:
-    """Write to file with provided content."""
-    success = True
+    """Write to file with provided content.
+    It's important to first set the permissions to then write the content because it might have
+    sensitive information like password.
+    """
+    path.touch()
+    if mode is not None:
+        os.chmod(path, mode)
     try:
         with open(path, "w", encoding="utf-8") as file:
             file.write(content)
-
-        if mode:
-            os.chmod(path, mode)
-    except (NotADirectoryError, PermissionError, OSError) as err:
+    except (NotADirectoryError, PermissionError) as err:
         logger.error(err)
         logger.info("Writing file to %s - Failed.", path)
-        success = False
-    else:
-        logger.info("Writing file to %s - Done.", path)
-    return success
+        return False
+
+    logger.info("Writing file to %s - Done.", path)
+    return True
 
 
 def remove_file(path: Path) -> bool:

--- a/src/service.py
+++ b/src/service.py
@@ -1,6 +1,5 @@
 """Exporter service helper."""
 
-import fcntl
 import os
 from abc import ABC, abstractmethod
 from logging import getLogger
@@ -282,8 +281,6 @@ def write_to_file(path: Path, content: str, mode: Optional[int] = None) -> bool:
     success = True
     try:
         with open(path, "w", encoding="utf-8") as file:
-            # Apply a file lock
-            fcntl.flock(file.fileno(), fcntl.LOCK_EX)
             file.write(content)
 
         if mode:

--- a/src/service.py
+++ b/src/service.py
@@ -282,10 +282,11 @@ def write_to_file(path: Path, content: str, mode: Optional[int] = None) -> bool:
     It's important to first set the permissions to then write the content because it might have
     sensitive information like password.
     """
-    path.touch()
-    if mode is not None:
-        os.chmod(path, mode)
     try:
+        path.touch()
+        if mode is not None:
+            os.chmod(path, mode)
+
         with open(path, "w", encoding="utf-8") as file:
             file.write(content)
     except (NotADirectoryError, PermissionError) as err:

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -817,8 +817,7 @@ class TestWriteToFile(unittest.TestCase):
 
         service.write_to_file(path, content_after)
 
-        final_content = path.read_text()
-        self.assertEqual(final_content, content_after)
+        self.assertEqual(path.read_text(), content_after)
 
     @mock.patch("builtins.open", new_callable=mock.mock_open)
     @mock.patch("service.os")

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -770,10 +770,9 @@ class TestWriteToFile(unittest.TestCase):
     def tearDown(self):
         pathlib.Path(self.temp_file.name).unlink()
 
-    @mock.patch("service.fcntl")
     @mock.patch("builtins.open", new_callable=mock.mock_open)
     @mock.patch("service.os")
-    def test_write_to_file_success(self, mock_os, mock_open, mock_fcntl):
+    def test_write_to_file_success(self, mock_os, mock_open):
         path = pathlib.Path(self.temp_file.name)
         content = "Hello, world!"
 
@@ -785,12 +784,10 @@ class TestWriteToFile(unittest.TestCase):
         mock_open.assert_called_with(path, "w", encoding="utf-8")
         mock_file.write.assert_called_with(content)
         mock_os.chmod.assert_not_called()
-        mock_fcntl.flock.assert_called_once()
 
-    @mock.patch("service.fcntl")
     @mock.patch("builtins.open", new_callable=mock.mock_open)
     @mock.patch("service.os")
-    def test_write_to_file_with_mode_success(self, mock_os, mock_open, mock_fcntl):
+    def test_write_to_file_with_mode_success(self, mock_os, mock_open):
         path = pathlib.Path(self.temp_file.name)
         content = "Hello, world!"
 
@@ -802,7 +799,6 @@ class TestWriteToFile(unittest.TestCase):
         mock_open.assert_called_with(path, "w", encoding="utf-8")
         mock_file.write.assert_called_with(content)
         mock_os.chmod.assert_called_with(path, 0o600)
-        mock_fcntl.flock.assert_called_once()
 
     @mock.patch("builtins.open", new_callable=mock.mock_open)
     def test_write_to_file_permission_error(self, mock_open):


### PR DESCRIPTION
Probably because of the usage of low level functions, as for example `os.open` and `os.fdopen`, it's harder to deal with buffering which can result into files with inconsistent content, which breaks the configuration and the hardware-exporter service.

After adding using high level functions and make the code simpler, the bug seems to be fixed

Closes: #305