### PR TITLE
Fix and restructure functional tests

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -20,6 +20,12 @@ def pytest_addoption(parser):
     )
 
     parser.addoption(
+        "--nvidia",
+        action="store_true",
+        help="Enable NVIDIA GPU support for testing with real hardware.",
+    )
+
+    parser.addoption(
         "--collectors",
         nargs="+",
         type=str.lower,
@@ -33,7 +39,6 @@ def pytest_addoption(parser):
             "poweredge_raid",
             "lsi_sas_2",
             "lsi_sas_3",
-            "dcgm",
         ],
         help="Provide space-separated list of collectors for testing with real hardware.",
     )
@@ -42,6 +47,11 @@ def pytest_addoption(parser):
 @pytest.fixture(scope="module")
 def base(request):
     return request.config.getoption("--base")
+
+
+@pytest.fixture(scope="module")
+def nvidia_present(request):
+    return request.config.getoption("--nvidia")
 
 
 @pytest.fixture(scope="module")

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -21,7 +21,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--base",
         type=str.lower,
-        default="ubuntu@20.04",
+        default="ubuntu@22.04",
         choices=BASES.keys(),
         help="Set base for the applications.",
     )

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -100,7 +100,7 @@ def resources() -> list[Resource]:
         Resource(
             resource_name=TPR_RESOURCES.get(HWTool.STORCLI),
             file_name="storcli.deb",
-            collector_name=HARDWARE_EXPORTER_COLLECTOR_MAPPING.get(HWTool.STORCLI)[0].replace(
+            collector_name=HARDWARE_EXPORTER_COLLECTOR_MAPPING.get(HWTool.STORCLI).replace(
                 "collector.", ""
             ),
             bin_name=HWTool.STORCLI.value,
@@ -108,7 +108,7 @@ def resources() -> list[Resource]:
         Resource(
             resource_name=TPR_RESOURCES.get(HWTool.PERCCLI),
             file_name="perccli.deb",
-            collector_name=HARDWARE_EXPORTER_COLLECTOR_MAPPING.get(HWTool.PERCCLI)[0].replace(
+            collector_name=HARDWARE_EXPORTER_COLLECTOR_MAPPING.get(HWTool.PERCCLI).replace(
                 "collector.", ""
             ),
             bin_name=HWTool.PERCCLI.value,
@@ -116,7 +116,7 @@ def resources() -> list[Resource]:
         Resource(
             resource_name=TPR_RESOURCES.get(HWTool.SAS2IRCU),
             file_name="sas2ircu",
-            collector_name=HARDWARE_EXPORTER_COLLECTOR_MAPPING.get(HWTool.SAS2IRCU)[0].replace(
+            collector_name=HARDWARE_EXPORTER_COLLECTOR_MAPPING.get(HWTool.SAS2IRCU).replace(
                 "collector.", ""
             ),
             bin_name=HWTool.SAS2IRCU.value,
@@ -124,7 +124,7 @@ def resources() -> list[Resource]:
         Resource(
             resource_name=TPR_RESOURCES.get(HWTool.SAS3IRCU),
             file_name="sas3ircu",
-            collector_name=HARDWARE_EXPORTER_COLLECTOR_MAPPING.get(HWTool.SAS3IRCU)[0].replace(
+            collector_name=HARDWARE_EXPORTER_COLLECTOR_MAPPING.get(HWTool.SAS3IRCU).replace(
                 "collector.", ""
             ),
             bin_name=HWTool.SAS3IRCU.value,

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import platform
 from pathlib import Path
 
@@ -152,11 +151,19 @@ def required_resources(resources: list[Resource], provided_collectors: set) -> l
 
 @pytest.fixture()
 def charm_path(base: str, architecture: str) -> Path:
-    """Fixture to determine the charm path based on the base."""
+    """Fixture to determine the charm path based on the base and architecture."""
     glob_path = f"hardware-observer_*{base.replace('@', '-')}-{architecture}*.charm"
     paths = list(Path(".").glob(glob_path))
 
     if not paths:
         raise FileNotFoundError(f"The path for the charm for {base}-{architecture} is not found.")
 
-    return os.getcwd() / paths[0]
+    if len(paths) > 1:
+        raise FileNotFoundError(
+            f"Multiple charms found for {base}-{architecture}. Please provide only one."
+        )
+
+    # The bundle will need the full path to the charm
+    path = paths[0].absolute()
+    log.info(f"Using charm path: {path}")
+    return path

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -33,6 +33,7 @@ def pytest_addoption(parser):
             "poweredge_raid",
             "lsi_sas_2",
             "lsi_sas_3",
+            "dcgm",
         ],
         help="Provide space-separated list of collectors for testing with real hardware.",
     )

--- a/tests/functional/test_charm.py
+++ b/tests/functional/test_charm.py
@@ -168,9 +168,9 @@ async def test_required_resources(ops_test: OpsTest, provided_collectors, requir
 
 
 @pytest.mark.abort_on_fail
-async def test_nvidia_driver_installation(ops_test: OpsTest, provided_collectors, unit):
+async def test_nvidia_driver_installation(ops_test: OpsTest, nvidia_present, unit):
     """Test nvidia driver installation."""
-    if "dcgm" not in provided_collectors:
+    if not nvidia_present:
         pytest.skip("dcgm not in provided collectors, skipping test")
 
     check_nvidia_driver_cmd = "cat /proc/driver/nvidia/version"
@@ -392,9 +392,9 @@ class TestCharmWithHW:
         assert results.get("return-code") == 0
         assert results.get("stdout").strip() == "active"
 
-    async def test_dcgm_exporter_snap_available(self, ops_test, app, unit, provided_collectors):
+    async def test_dcgm_exporter_snap_available(self, ops_test, app, unit, nvidia_present):
         """Test if dcgm exporter snap is installed and ranning on the unit."""
-        if "dcgm" not in provided_collectors:
+        if not nvidia_present:
             pytest.skip("dcgm not in provided collectors, skipping test")
 
         snap_name = "dcgm"

--- a/tests/functional/test_charm.py
+++ b/tests/functional/test_charm.py
@@ -65,7 +65,7 @@ class AppStatus(str, Enum):
 @pytest.mark.abort_on_fail
 @pytest.mark.skip_if_deployed
 async def test_build_and_deploy(  # noqa: C901, function is too complex
-    ops_test: OpsTest, base, architecture, provided_collectors, required_resources, charm_path
+    ops_test: OpsTest, base, architecture, realhw, required_resources, charm_path
 ):
     """Deploy the charm together with related charms.
 
@@ -96,7 +96,7 @@ async def test_build_and_deploy(  # noqa: C901, function is too complex
 
     # deploy bundle to already added machine instead of provisioning new one
     # when testing with real hardware
-    if provided_collectors:
+    if realhw:
         juju_cmd.append("--map-machines=existing")
 
     logging.info("Deploying bundle...")
@@ -168,6 +168,7 @@ async def test_required_resources(ops_test: OpsTest, provided_collectors, requir
 
 
 @pytest.mark.abort_on_fail
+@pytest.mark.realhw
 async def test_nvidia_driver_installation(ops_test: OpsTest, nvidia_present, unit):
     """Test nvidia driver installation."""
     if not nvidia_present:

--- a/tests/functional/test_charm.py
+++ b/tests/functional/test_charm.py
@@ -262,7 +262,7 @@ class TestCharmWithHW:
         assert config["redfish_client_timeout"] == int(new_timeout)
 
         await app.reset_config(["collect-timeout"])
-        
+
     async def test_smarctl_exporter_snap_available(self, ops_test, app, unit):
         """Test if smartctl exporter snap is installed and ranning on the unit."""
         snap_name = "smartctl-exporter"
@@ -270,7 +270,7 @@ class TestCharmWithHW:
         results = await run_command_on_unit(ops_test, unit.name, cmd)
         assert results.get("return-code") == 0
         assert snap_name in results.get("stdout").strip()
-        
+
         check_active_cmd = "systemctl is-active snap.smartctl-exporter.smartctl-exporter"
         results = await run_command_on_unit(ops_test, unit.name, check_active_cmd)
         assert results.get("return-code") == 0

--- a/tests/functional/test_charm.py
+++ b/tests/functional/test_charm.py
@@ -469,8 +469,10 @@ class TestCharmWithHW:
             results = await run_command_on_unit(ops_test, unit.name, check_resource_cmd)
             assert results.get("return-code") == 0, f"{symlink_bin} resource doesn't exist"
 
-    async def test_redfish_config(self, app, unit, ops_test):
+    async def test_redfish_config(self, ops_test, app, unit, provided_collectors):
         """Test Redfish options."""
+        if "redfish" not in provided_collectors:
+            pytest.skip("redfish not in provided collectors, skipping test")
         # initially Redfish is available and enabled
         cmd = "cat /etc/hardware-exporter-config.yaml"
         results_before = await run_command_on_unit(ops_test, unit.name, cmd)
@@ -584,7 +586,6 @@ class TestCharmWithHW:
         )
 
 
-@pytest.mark.realhw
 class TestCharm:
     """Perform tests that require one or more exporters to be present."""
 

--- a/tests/functional/test_charm.py
+++ b/tests/functional/test_charm.py
@@ -262,6 +262,19 @@ class TestCharmWithHW:
         assert config["redfish_client_timeout"] == int(new_timeout)
 
         await app.reset_config(["collect-timeout"])
+        
+    async def test_smarctl_exporter_snap_available(self, ops_test, app, unit):
+        """Test if smartctl exporter snap is installed and ranning on the unit."""
+        snap_name = "smartctl-exporter"
+        cmd = f"snap list {snap_name}"
+        results = await run_command_on_unit(ops_test, unit.name, cmd)
+        assert results.get("return-code") == 0
+        assert snap_name in results.get("stdout").strip()
+        
+        check_active_cmd = "systemctl is-active snap.smartctl-exporter.smartctl-exporter"
+        results = await run_command_on_unit(ops_test, unit.name, check_active_cmd)
+        assert results.get("return-code") == 0
+        assert results.get("stdout").strip() == "active"
 
     async def test_metrics_available(self, app, unit, ops_test):
         """Test if metrics are available at the expected endpoint on unit."""

--- a/tests/functional/test_charm.py
+++ b/tests/functional/test_charm.py
@@ -56,17 +56,13 @@ class AppStatus(str, Enum):
 @pytest.mark.abort_on_fail
 @pytest.mark.skip_if_deployed
 async def test_build_and_deploy(  # noqa: C901, function is too complex
-    ops_test: OpsTest, base, architecture, provided_collectors, required_resources
+    ops_test: OpsTest, base, architecture, provided_collectors, required_resources, charm_path
 ):
-    """Build the charm-under-test and deploy it together with related charms.
+    """Deploy the charm together with related charms.
 
     Assert on the unit status before any relations/configurations take place.
     Optionally attach required resources when testing with real hardware.
     """
-    # Build and deploy charm from local source folder
-    charm = await ops_test.build_charm(".")
-    assert charm, "Charm was not built successfully."
-
     # This is required for subordinate appliation to choose right revison
     # on different architecture.
     # See issue: https://bugs.launchpad.net/juju/+bug/2067749
@@ -77,7 +73,7 @@ async def test_build_and_deploy(  # noqa: C901, function is too complex
     logger.info("Rendering bundle %s", bundle_template_path)
     bundle = ops_test.render_bundle(
         bundle_template_path,
-        charm=charm,
+        charm=charm_path,
         base=base,
         resources={
             "storcli-deb": "empty-resource",

--- a/tests/functional/test_charm.py
+++ b/tests/functional/test_charm.py
@@ -162,7 +162,6 @@ async def test_required_resources(ops_test: OpsTest, provided_collectors, requir
         assert unit.workload_status_message == AppStatus.MISSING_RELATION
 
 
-@pytest.mark.realhw
 @pytest.mark.abort_on_fail
 async def test_cos_agent_relation(ops_test: OpsTest, provided_collectors):
     """Test adding relation with grafana-agent."""
@@ -225,7 +224,6 @@ async def test_redfish_credential_validation(ops_test: OpsTest, provided_collect
         assert unit.workload_status_message == AppStatus.READY
 
 
-@pytest.mark.realhw
 class TestCharmWithHW:
     """Run functional tests that require specific hardware."""
 

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -84,6 +84,15 @@ async def get_metrics_output(ops_test, unit_name) -> Optional[dict[str, list[Met
     return parsed_metrics
 
 
+async def assert_snap_installed(ops_test, unit_name: str, snap_name: str) -> bool:
+    """Assert whether snap is installed on the model."""
+    cmd = f"snap list {snap_name}"
+    results = await run_command_on_unit(ops_test, unit_name, cmd)
+    if results.get("return-code") > 0 or snap_name not in results.get("stdout"):
+        return False
+    return True
+
+
 def assert_metrics(metrics: list[Metric], expected_metric_values_map: dict[str, float]) -> bool:
     """Assert whether values in obtained list of metrics for a collector are as expected.
 

--- a/tox.ini
+++ b/tox.ini
@@ -69,6 +69,7 @@ deps =
 passenv =
     REDFISH_USERNAME
     REDFISH_PASSWORD
+    CHARM_PATH_*
 
 [testenv:integration]
 description = Run integration tests with COS


### PR DESCRIPTION
- Add a test to check if snaps are installed
- Fixes some bugs in the functional test suit
- Removes duplicate build step in the functional test (now the artifact build during the check workflow is used)
- Restructure the functional tests to represent the current logic involving `hardware-exporter.`
- Add a test to check if the charm manages to install the Nvidia drivers, if `--nvidia` flag is provided.
- Add a `--realhw` for the real hardware tests.

The hardware-independent tests were built assuming the `hardware-exporter` service and the config would still be rendered if no hardware was detected. This is not the case anymore, so it limits the number of tests we can run in the CI. But I've confirmed that the tests are passing on real hardware with the changes.

Closes: #351 