### PR TITLE
Disable trigger of cos_integration in PR

### DIFF
--- a/.github/workflows/cos_integration.yaml
+++ b/.github/workflows/cos_integration.yaml
@@ -6,9 +6,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     branches: [main]
-    paths-ignore:
-      - "**.md"
-      - "**.rst"
+    paths:
+      - ".github/workflows/cos_integration.yaml"
 
 jobs:
   integration:


### PR DESCRIPTION
The cos_integration workflow should be triggered only by dispatch or, when the workflow was changed and not for all PR.

fixes: #344