### PR TITLE
Don't install DCGM if the driver has been blacklisted

### DIFF
--- a/src/hw_tools.py
+++ b/src/hw_tools.py
@@ -687,12 +687,11 @@ def nvidia_gpu_verifier() -> Set[HWTool]:
 
 def _is_nvidia_module_blacklisted() -> bool:
     module_re = re.compile(r"blacklist\s+nvidia")
-    for conffile in chain(iglob("/etc/modprobe.d/*.conf"), "/etc/modprobe.conf"):
+    for conffile in chain(iglob("/etc/modprobe.d/*.conf"), ["/etc/modprobe.conf"]):
         try:
             with open(conffile, "r", encoding="utf-8") as fd:
-                for line in fd.readline():
-                    if module_re.match(line):
-                        return True
+                if any(module_re.match(line) for line in fd.readline()):
+                    return True
         except (IsADirectoryError, FileNotFoundError):
             # glob may match directories, and modprobe.conf may or may not exist
             continue


### PR DESCRIPTION
If the sysadmin wants to pass the gpu to a virtual instance via pci
passthrough, they will need to make the gpu unavailable to the host
system by blacklisting the kernel driver. On such a system DCGM would
not be able to function and should therefore not be deployed.

This commit makes the NVIDIA gpu verifier more strict by only marking
DCGM as an available tool if both an NVIDIA gpu is detected *and* the
kernel module is not blacklisted.

Fixes: #362

## Testing setup

Given a server with an NVIDIA gpu, drivers installed, and modules blacklisted via modprobe:
```
$ cat /etc/modprobe.d/blacklist-nvidia.conf 
blacklist nvidia
blacklist nvidiafb
blacklist nouveau
blacklist nvidia_drm
```

Following the `dev-environment.md` file, set up a local controller deploy an older stable charm (e.g. rev 84), setting up resources if necessary.

Next pack the charm from this commit, scp it to the server, and install it:
```
$ juju refresh --switch ./hardware-observer_ubuntu-24.04-amd64_ubuntu-22.04-amd64_ubuntu-20.04-amd64.charm  hardware-observer
```

Expected result:
* DCGM is not installed
* the nvidia driver remains not loaded
* charm remains in active idle