### PR TITLE
Store tools as a set of strings

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -115,7 +115,7 @@ class HardwareObserverCharm(ops.CharmBase):
 
         if event.params["apply"] and hw_change_detected:
             # Update the value in local Store
-            self._stored.stored_tools = available_tools
+            self._stored.stored_tools = {tool.value for tool in available_tools}
             event.log(f"Run install hook with enable tools: {sorted_available_tools}")
             self._on_install_or_upgrade(event=event)
 


### PR DESCRIPTION
As noted in `get_stored_tools()`, StoredState cannot store arbitrary objects; this commit applies the same logic to `_on_redetect_hardware()`

Note: it would be nice to turn `stored_tools` into a property, but that requires a lot of unit test updates.

Fixes: #364 