### PR TITLE
Make stored_tools a property

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -70,52 +70,61 @@ class HardwareObserverCharm(ops.CharmBase):
     def exporters(self) -> List[BaseExporter]:
         """Return list of exporters based on detected hardware."""
         exporters: List[BaseExporter] = []
-        stored_tools = self.get_stored_tools()
-        if stored_tools & HardwareExporter.hw_tools():
+        if self.stored_tools & HardwareExporter.hw_tools():
             exporters.append(
                 HardwareExporter(
                     self.charm_dir,
                     self.model.config,
-                    stored_tools,
+                    self.stored_tools,
                 )
             )
 
-        if stored_tools & SmartCtlExporter.hw_tools():
+        if self.stored_tools & SmartCtlExporter.hw_tools():
             exporters.append(SmartCtlExporter(self.model.config))
 
-        if stored_tools & DCGMExporter.hw_tools():
+        if self.stored_tools & DCGMExporter.hw_tools():
             exporters.append(DCGMExporter(self.model.config))
 
         return exporters
 
-    def get_stored_tools(self) -> Set[HWTool]:
+    @property
+    def stored_tools(self) -> Set[HWTool]:
         """Get the current hardware tools from stored or from machine if not present.
 
-        This function stores the current hardware tools as strings because StoredState cannot store
-        arbitrary objects. HWTool objects can however be re-instantiated from tool names.
+        Since StoredState cannot store arbitrary objects, re-instantiate tools from tool names.
         """
         if not self._stored.stored_tools:  # type: ignore[truthy-function]
-            available_tools = detect_available_tools()  # type: ignore[unreachable]
-            self._stored.stored_tools = {tool.value for tool in available_tools}
-        if "smartctl" in self._stored.stored_tools:  # type: ignore[operator]
-            self._stored.stored_tools.remove("smartctl")  # type: ignore[attr-defined]
+            self._stored.stored_tools = {  # type: ignore[unreachable]
+                tool.value for tool in detect_available_tools()
+            }
+        # remove legacy smartctl tool if present
+        # See https://github.com/canonical/hardware-observer-operator/pull/327
+        self._stored.stored_tools.discard("smartctl")  # type: ignore[attr-defined]
         return {HWTool(value) for value in self._stored.stored_tools}  # type: ignore[attr-defined]
+
+    @stored_tools.setter
+    def stored_tools(self, tools: Set[HWTool]) -> None:
+        """Record the tools via StoredState.
+
+        StoredState cannot store arbitrary objects so we convert Set[HWTool] into Set[str].
+        This is reversible by re-instantiating tools from tool names.
+        """
+        self._stored.stored_tools = {tool.value for tool in tools}
 
     def _on_redetect_hardware(self, event: ops.ActionEvent) -> None:
         """Redetect available hardware tools and option to rerun the install hook."""
-        stored_tools = self.get_stored_tools()
         available_tools = detect_available_tools()
 
-        hw_change_detected = stored_tools != available_tools
+        hw_change_detected = self.stored_tools != available_tools
 
-        sorted_stored_tools = ",".join(map(lambda member: member.value, sorted(stored_tools)))
+        sorted_stored_tools = ",".join(map(lambda member: member.value, sorted(self.stored_tools)))
         sorted_available_tools = ",".join(
             map(lambda member: member.value, sorted(available_tools))
         )
 
         if event.params["apply"] and hw_change_detected:
             # Update the value in local Store
-            self._stored.stored_tools = {tool.value for tool in available_tools}
+            self.stored_tools = available_tools
             event.log(f"Run install hook with enable tools: {sorted_available_tools}")
             self._on_install_or_upgrade(event=event)
 
@@ -134,13 +143,13 @@ class HardwareObserverCharm(ops.CharmBase):
 
         remove_legacy_smartctl_exporter()
 
-        stored_tools = self.get_stored_tools()
-
         msg: str
         resource_installed: bool
 
         # Install hw tools
-        resource_installed, msg = self.hw_tool_helper.install(self.model.resources, stored_tools)
+        resource_installed, msg = self.hw_tool_helper.install(
+            self.model.resources, self.stored_tools
+        )
 
         self._stored.resource_installed = resource_installed
         if not resource_installed:
@@ -167,7 +176,7 @@ class HardwareObserverCharm(ops.CharmBase):
         # Remove binary tool
         self.hw_tool_helper.remove(
             self.model.resources,
-            self.get_stored_tools(),
+            self.stored_tools,
         )
         self._stored.resource_installed = False
 
@@ -192,7 +201,7 @@ class HardwareObserverCharm(ops.CharmBase):
                 self.model.unit.status = BlockedStatus(config_valid_message)
                 return
 
-        hw_tool_ok, error_msg = self.hw_tool_helper.check_installed(self.get_stored_tools())
+        hw_tool_ok, error_msg = self.hw_tool_helper.check_installed(self.stored_tools)
         if not hw_tool_ok:
             self.model.unit.status = BlockedStatus(error_msg)
             return

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -82,29 +82,32 @@ class TestCharm(unittest.TestCase):
     def test_exporters(
         self, _, stored_tools, expect, mock_hw_exporter, mock_smart_exporter, mock_dcgm_exporter
     ):
-        self.harness.begin()
-        self.harness.charm.get_stored_tools = mock.MagicMock()
-        self.harness.charm.get_stored_tools.return_value = stored_tools
+        with mock.patch(
+            "charm.HardwareObserverCharm.stored_tools",
+            new_callable=mock.PropertyMock(
+                return_value=stored_tools,
+            ),
+        ):
+            self.harness.begin()
 
-        hw_exporter = mock.MagicMock()
-        hw_exporter.exporter_name = HARDWARE_EXPORTER_SETTINGS.name
-        mock_hw_exporter.hw_tools.return_value = HardwareExporter.hw_tools()
-        mock_hw_exporter.return_value = hw_exporter
+            hw_exporter = mock.MagicMock()
+            hw_exporter.exporter_name = HARDWARE_EXPORTER_SETTINGS.name
+            mock_hw_exporter.hw_tools.return_value = HardwareExporter.hw_tools()
+            mock_hw_exporter.return_value = hw_exporter
 
-        smart_exporter = mock.MagicMock()
-        smart_exporter.exporter_name = SmartCtlExporter.exporter_name
-        mock_smart_exporter.hw_tools.return_value = SmartCtlExporter.hw_tools()
-        mock_smart_exporter.return_value = smart_exporter
+            smart_exporter = mock.MagicMock()
+            smart_exporter.exporter_name = SmartCtlExporter.exporter_name
+            mock_smart_exporter.hw_tools.return_value = SmartCtlExporter.hw_tools()
+            mock_smart_exporter.return_value = smart_exporter
 
-        dcgm_exporter = mock.MagicMock()
-        dcgm_exporter.exporter_name = DCGMExporter.exporter_name
-        mock_dcgm_exporter.hw_tools.return_value = DCGMExporter.hw_tools()
-        mock_dcgm_exporter.return_value = dcgm_exporter
+            dcgm_exporter = mock.MagicMock()
+            dcgm_exporter.exporter_name = DCGMExporter.exporter_name
+            mock_dcgm_exporter.hw_tools.return_value = DCGMExporter.hw_tools()
+            mock_dcgm_exporter.return_value = dcgm_exporter
 
-        exporters = self.harness.charm.exporters
-        self.harness.charm.get_stored_tools.assert_called()
+            exporters = self.harness.charm.exporters
 
-        self.assertEqual({exporter.exporter_name for exporter in exporters}, expect)
+            self.assertEqual({exporter.exporter_name for exporter in exporters}, expect)
 
     @parameterized.expand(
         [
@@ -167,17 +170,23 @@ class TestCharm(unittest.TestCase):
         mock_exporters,
         mock_exporter_install_returns,
     ) -> None:
-        with mock.patch(
-            "charm.HardwareObserverCharm.exporters",
-            new_callable=mock.PropertyMock(
-                return_value=mock_exporters,
-            ),
-        ) as mock_exporters:
+        with (
+            mock.patch(
+                "charm.HardwareObserverCharm.exporters",
+                new_callable=mock.PropertyMock(
+                    return_value=mock_exporters,
+                ),
+            ) as mock_exporters,
+            mock.patch(
+                "charm.HardwareObserverCharm.stored_tools",
+                new_callable=mock.PropertyMock(
+                    return_value=stored_tools,
+                ),
+            ) as mock_stored_tools,  # noqa: F841
+        ):
             self.harness.begin()
             self.harness.charm.hw_tool_helper = mock.MagicMock()
             self.harness.charm.hw_tool_helper.install.return_value = hw_tool_helper_install_return
-            self.harness.charm.get_stored_tools = mock.MagicMock()
-            self.harness.charm.get_stored_tools.return_value = stored_tools
             self.harness.charm._on_update_status = mock.MagicMock()
 
             for mock_exporter, return_val in zip(
@@ -208,27 +217,28 @@ class TestCharm(unittest.TestCase):
 
     def test_remove(self):
         mock_exporters = {mock.MagicMock(), mock.MagicMock()}
-        with mock.patch(
-            "charm.HardwareObserverCharm.exporters",
-            new_callable=mock.PropertyMock(
-                return_value=mock_exporters,
-            ),
-        ) as mock_exporters:
+        mock_stored_tools = {HWTool.IPMI_SENSOR, HWTool.IPMI_SEL, HWTool.SMARTCTL_EXPORTER}
+        with (
+            mock.patch(
+                "charm.HardwareObserverCharm.exporters",
+                new_callable=mock.PropertyMock(
+                    return_value=mock_exporters,
+                ),
+            ) as mock_exporters,
+            mock.patch(
+                "charm.HardwareObserverCharm.stored_tools",
+                new_callable=mock.PropertyMock(
+                    return_value=mock_stored_tools,
+                ),
+            ) as mock_stored_tools,
+        ):
             self.harness.begin()
             self.harness.charm.hw_tool_helper = mock.MagicMock()
-
-            self.harness.charm.get_stored_tools = mock.MagicMock()
-            self.harness.charm.get_stored_tools.return_value = {
-                HWTool.IPMI_SENSOR,
-                HWTool.IPMI_SEL,
-                HWTool.SMARTCTL_EXPORTER,
-            }
 
             self.harness.charm.on.remove.emit()
 
         self.harness.charm.hw_tool_helper.remove.assert_called_with(
-            self.harness.charm.model.resources,
-            {HWTool.IPMI_SENSOR, HWTool.IPMI_SEL, HWTool.SMARTCTL_EXPORTER},
+            self.harness.charm.model.resources, mock_stored_tools
         )
         for mock_exporter in mock_exporters:
             mock_exporter.uninstall.assert_called()
@@ -362,7 +372,7 @@ class TestCharm(unittest.TestCase):
             return
 
         self.harness.charm.hw_tool_helper.check_installed.assert_called_with(
-            self.harness.charm.get_stored_tools()
+            self.harness.charm.stored_tools
         )
         if not hw_tool_check_installed[0]:
             self.assertEqual(
@@ -462,7 +472,7 @@ class TestCharm(unittest.TestCase):
         mock_detect_available_tools.return_value = detected_available_tools
         self.harness.begin()
         self.harness.charm._on_install_or_upgrade = mock.MagicMock()
-        self.harness.charm._stored.stored_tools = [tool.value for tool in stored_tools]
+        self.harness.charm.stored_tools = stored_tools
 
         output = self.harness.run_action("redetect-hardware", {"apply": apply})
 
@@ -471,14 +481,14 @@ class TestCharm(unittest.TestCase):
         if not stored_tools == detected_available_tools:
             if apply:
                 self.assertEqual(
-                    self.harness.charm.get_stored_tools(),
+                    self.harness.charm.stored_tools,
                     detected_available_tools,
                 )
                 self.harness.charm._on_install_or_upgrade.assert_called()
             else:
                 self.harness.charm._on_install_or_upgrade.assert_not_called()
                 self.assertEqual(
-                    self.harness.charm.get_stored_tools(),
+                    self.harness.charm.stored_tools,
                     {tool.value for tool in stored_tools},
                 )
         else:
@@ -599,11 +609,20 @@ class TestCharm(unittest.TestCase):
         mock_exporter.validate_exporter_configs.return_value = (True, "")
         mock_exporter.check_health.return_value = True
         mock_exporters = [mock_exporter]
+        mock_stored_tools = {HWTool.IPMI_SENSOR, HWTool.IPMI_SEL, HWTool.IPMI_DCMI}
 
-        with mock.patch(
-            "charm.HardwareObserverCharm.exporters",
-            new_callable=mock.PropertyMock(
-                return_value=mock_exporters,
+        with (
+            mock.patch(
+                "charm.HardwareObserverCharm.exporters",
+                new_callable=mock.PropertyMock(
+                    return_value=mock_exporters,
+                ),
+            ),
+            mock.patch(
+                "charm.HardwareObserverCharm.stored_tools",
+                new_callable=mock.PropertyMock(
+                    return_value=mock_stored_tools,
+                ),
             ),
         ):
             rid = self.harness.add_relation("cos-agent", "grafana-agent")
@@ -613,13 +632,6 @@ class TestCharm(unittest.TestCase):
             self.harness.charm.hw_tool_helper = mock.MagicMock()
             self.harness.charm.hw_tool_helper.install.return_value = (True, "")
             self.harness.charm.hw_tool_helper.check_installed.return_value = (True, "")
-
-            self.harness.charm.get_stored_tools = mock.MagicMock()
-            self.harness.charm.get_stored_tools.return_value = {
-                HWTool.IPMI_SENSOR,
-                HWTool.IPMI_SEL,
-                HWTool.IPMI_DCMI,
-            }
 
             self.harness.charm.on.install.emit()
             self.harness.add_relation_unit(rid, "grafana-agent/0")
@@ -665,12 +677,14 @@ class TestCharm(unittest.TestCase):
             self.harness.charm.hw_tool_helper.install.return_value = (True, "")
             self.harness.charm.hw_tool_helper.check_installed.return_value = (True, "")
 
-            self.harness.charm.get_stored_tools = mock.MagicMock()
-            self.harness.charm.get_stored_tools.return_value = [
-                HWTool.IPMI_SENSOR,
-                HWTool.IPMI_SEL,
-                HWTool.IPMI_DCMI,
-            ]
+            mock_stored_tools = mock.MagicMock()
+            type(mock_stored_tools).stored_tools = mock.PropertyMock(
+                return_value=[
+                    HWTool.IPMI_SENSOR,
+                    HWTool.IPMI_SEL,
+                    HWTool.IPMI_DCMI,
+                ]
+            )
 
             self.harness.charm.on.install.emit()
             self.harness.add_relation_unit(rid, "grafana-agent/0")
@@ -787,7 +801,7 @@ class TestCharm(unittest.TestCase):
             result = self.harness.charm.validate_configs()
             self.assertEqual(result, expect)
 
-    def test_get_stored_tools_remove_legacy_smartctl(self):
+    def test_stored_tools_remove_legacy_smartctl(self):
         self.harness.begin()
         self.harness.charm._stored.stored_tools = {"smartctl"}
-        assert self.harness.charm.get_stored_tools() == set()
+        assert self.harness.charm.stored_tools == set()


### PR DESCRIPTION
By making stored_tools a property we avoid the awkwardness of having to
continuously convert back and forth between Set[HWTool] and Set[str]
(which can be handled by StoredState)
