### PR TITLE
Fix SmartAttributeWarning alert

### DIFF
--- a/src/prometheus_alert_rules/smart.yaml
+++ b/src/prometheus_alert_rules/smart.yaml
@@ -88,7 +88,7 @@ groups:
 
   - alert: SmartAttributeWarning
     # based on https://www.backblaze.com/blog/what-smart-stats-indicate-hard-drive-failures/
-    expr: smartctl_device_attribute{attribute_id=~"5|187|188|197|198"} > 0
+    expr: smartctl_device_attribute{attribute_id=~"5|187|188|197|198", attribute_value_type="raw"} > 0
     for: 2m
     labels:
       severity: warning

--- a/tests/unit/test_alert_rules/test_smart.yaml
+++ b/tests/unit/test_alert_rules/test_smart.yaml
@@ -168,7 +168,7 @@ tests:
 
   - interval: 1m
     input_series:
-      - series: 'smartctl_device_attribute{device="sda", attribute_id="5", attribute_name="Reallocated_Sectors_Count", instance="ubuntu-2"}'
+      - series: 'smartctl_device_attribute{device="sda", attribute_id="5", attribute_name="Reallocated_Sectors_Count", instance="ubuntu-2", attribute_value_type="raw"}'
         values: '2x10'
 
     alert_rule_test:
@@ -181,13 +181,14 @@ tests:
               device: sda
               attribute_id: 5
               attribute_name: Reallocated_Sectors_Count
+              attribute_value_type: raw
             exp_annotations:
               summary: SMART device attribute correlating with drive failure has its raw value greater than zero. (instance ubuntu-2)
               description: |
                 SMART raw value for attribute "Reallocated_Sectors_Count" with id "5"
                 on device "sda" is greater than 0.
                   VALUE = 2
-                  LABELS = map[__name__:smartctl_device_attribute attribute_id:5 attribute_name:Reallocated_Sectors_Count device:sda instance:ubuntu-2]
+                  LABELS = map[__name__:smartctl_device_attribute attribute_id:5 attribute_name:Reallocated_Sectors_Count attribute_value_type:raw device:sda instance:ubuntu-2]
 
   - interval: 1m
     input_series:


### PR DESCRIPTION
Only fire the alert if the `attribute_value_type="raw"` is set. The issue was in the fact that there are several entries for the attribute, which includes `value`, `worst` and `thresh`:

```

smartctl_device_attribute{attribute_flags_long="prefailure,updated_online,event_count,auto_keep", attribute_flags_short="PO--CK", attribute_id="5", attribute_name="Reallocated_Sector_Ct", attribute_value_type="raw", device="sda", instance="localhost:10201", job="hardware-observer_2_default", juju_application="hardware-observer", juju_model="hw-obs", juju_model_uuid="80a2c1d6-1a90-4ef0-8132-af698cf34f60", juju_unit="hardware-observer/1"}
0
smartctl_device_attribute{attribute_flags_long="prefailure,updated_online,event_count,auto_keep", attribute_flags_short="PO--CK", attribute_id="5", attribute_name="Reallocated_Sector_Ct", attribute_value_type="thresh", device="sda", instance="localhost:10201", job="hardware-observer_2_default", juju_application="hardware-observer", juju_model="hw-obs", juju_model_uuid="80a2c1d6-1a90-4ef0-8132-af698cf34f60", juju_unit="hardware-observer/1"}
10
smartctl_device_attribute{attribute_flags_long="prefailure,updated_online,event_count,auto_keep", attribute_flags_short="PO--CK", attribute_id="5", attribute_name="Reallocated_Sector_Ct", attribute_value_type="value", device="sda", instance="localhost:10201", job="hardware-observer_2_default", juju_application="hardware-observer", juju_model="hw-obs", juju_model_uuid="80a2c1d6-1a90-4ef0-8132-af698cf34f60", juju_unit="hardware-observer/1"}
100
smartctl_device_attribute{attribute_flags_long="prefailure,updated_online,event_count,auto_keep", attribute_flags_short="PO--CK", attribute_id="5", attribute_name="Reallocated_Sector_Ct", attribute_value_type="worst", device="sda", instance="localhost:10201", job="hardware-observer_2_default", juju_application="hardware-observer", juju_model="hw-obs", juju_model_uuid="80a2c1d6-1a90-4ef0-8132-af698cf34f60", juju_unit="hardware-observer/1"}
```

Coming from the `smartctl` CLI:

```
ID# ATTRIBUTE_NAME          FLAG     VALUE WORST THRESH TYPE      UPDATED  WHEN_FAILED RAW_VALUE
  5 Reallocated_Sector_Ct   0x0033   100   100   010    Pre-fail  Always       -       0
```

Fixes: #358