### PR TITLE
Replace `instance` to `juju_unit` for the metric joins

### DIFF
--- a/src/grafana_dashboards/smart.json
+++ b/src/grafana_dashboards/smart.json
@@ -835,7 +835,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "smartctl_device_attribute{instance=~\"$instance\", job=\"$job\"} * on(device, instance) group_left(model_name) smartctl_device{instance=~\"$instance\", job=\"$job\"}",
+          "expr": "smartctl_device_attribute{instance=~\"$instance\", job=\"$job\"} * on(device, juju_unit) group_left(model_name) smartctl_device{instance=~\"$instance\", job=\"$job\"}",
           "range": false,
           "instant": true,
           "format": "table",
@@ -961,7 +961,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (model_name) (smartctl_device_temperature{instance=~\"$instance\", job=\"$job\",temperature_type=\"current\"} * on(device, instance) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
+          "expr": "sum by (model_name) (smartctl_device_temperature{instance=~\"$instance\", job=\"$job\",temperature_type=\"current\"} * on(device, juju_unit) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
           "legendFormat": "{{ model_name }}",
           "range": true,
           "instant": false,
@@ -1046,7 +1046,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (model_name) (smartctl_device_smartctl_exit_status{instance=~\"$instance\", job=\"$job\"} * on(device, instance) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
+          "expr": "sum by (model_name) (smartctl_device_smartctl_exit_status{instance=~\"$instance\", job=\"$job\"} * on(device, juju_unit) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
           "legendFormat": "{{ model_name }}",
           "range": true,
           "instant": false,
@@ -1131,7 +1131,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (model_name) (smartctl_device_smart_status{instance=~\"$instance\", job=\"$job\"} * on(device, instance) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
+          "expr": "sum by (model_name) (smartctl_device_smart_status{instance=~\"$instance\", job=\"$job\"} * on(device, juju_unit) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
           "legendFormat": "{{ model_name }}",
           "range": true,
           "instant": false,
@@ -1216,7 +1216,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (model_name) (increase(smartctl_device_power_on_seconds{instance=~\"$instance\", job=\"$job\"}[1h]) * on(device, instance) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
+          "expr": "sum by (model_name) (increase(smartctl_device_power_on_seconds{instance=~\"$instance\", job=\"$job\"}[1h]) * on(device, juju_unit) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
           "legendFormat": "{{ model_name }}",
           "range": true,
           "instant": false,
@@ -1301,7 +1301,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (model_name) (smartctl_device_power_cycle_count{instance=~\"$instance\", job=\"$job\"} * on(device, instance) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
+          "expr": "sum by (model_name) (smartctl_device_power_cycle_count{instance=~\"$instance\", job=\"$job\"} * on(device, juju_unit) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
           "legendFormat": "{{ model_name }}",
           "range": true,
           "instant": false,
@@ -1386,7 +1386,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (model_name) (smartctl_device_percentage_used{instance=~\"$instance\", job=\"$job\"} * on(device, instance) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
+          "expr": "sum by (model_name) (smartctl_device_percentage_used{instance=~\"$instance\", job=\"$job\"} * on(device, juju_unit) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
           "legendFormat": "{{ model_name }}",
           "range": true,
           "instant": false,
@@ -1471,7 +1471,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (model_name) (smartctl_device_nvme_capacity_bytes{instance=~\"$instance\", job=\"$job\"} * on(device, instance) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
+          "expr": "sum by (model_name) (smartctl_device_nvme_capacity_bytes{instance=~\"$instance\", job=\"$job\"} * on(device, juju_unit) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
           "legendFormat": "{{ model_name }}",
           "range": true,
           "instant": false,
@@ -1556,7 +1556,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (model_name) (smartctl_device_num_err_log_entries{instance=~\"$instance\", job=\"$job\"} * on(device, instance) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
+          "expr": "sum by (model_name) (smartctl_device_num_err_log_entries{instance=~\"$instance\", job=\"$job\"} * on(device, juju_unit) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
           "legendFormat": "{{ model_name }}",
           "range": true,
           "instant": false,
@@ -1642,7 +1642,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (model_name) (smartctl_device_media_errors{instance=~\"$instance\", job=\"$job\"} * on(device, instance) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
+          "expr": "sum by (model_name) (smartctl_device_media_errors{instance=~\"$instance\", job=\"$job\"} * on(device, juju_unit) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
           "legendFormat": "{{ model_name }}",
           "range": true,
           "instant": false,
@@ -1728,7 +1728,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (model_name) (smartctl_device_error_log_count{instance=~\"$instance\", job=\"$job\",error_log_type=\"summary\"} * on(device, instance) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
+          "expr": "sum by (model_name) (smartctl_device_error_log_count{instance=~\"$instance\", job=\"$job\",error_log_type=\"summary\"} * on(device, juju_unit) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
           "legendFormat": "{{ model_name }}",
           "range": true,
           "instant": false,
@@ -1813,7 +1813,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (model_name) (smartctl_device_critical_warning{instance=~\"$instance\", job=\"$job\"} * on(device, instance) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
+          "expr": "sum by (model_name) (smartctl_device_critical_warning{instance=~\"$instance\", job=\"$job\"} * on(device, juju_unit) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
           "legendFormat": "{{ model_name }}",
           "range": true,
           "instant": false,
@@ -1898,7 +1898,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (model_name) (smartctl_device_interface_speed{instance=~\"$instance\", job=\"$job\",speed_type=\"current\"} * on(device, instance) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
+          "expr": "sum by (model_name) (smartctl_device_interface_speed{instance=~\"$instance\", job=\"$job\",speed_type=\"current\"} * on(device, juju_unit) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
           "legendFormat": "{{ model_name }}",
           "range": true,
           "instant": false,
@@ -1983,7 +1983,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (model_name) (smartctl_device_interface_speed{instance=~\"$instance\", job=\"$job\",speed_type=\"max\"} * on(device, instance) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
+          "expr": "sum by (model_name) (smartctl_device_interface_speed{instance=~\"$instance\", job=\"$job\",speed_type=\"max\"} * on(device, juju_unit) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
           "legendFormat": "{{ model_name }}",
           "range": true,
           "instant": false,
@@ -2068,7 +2068,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (model_name) (smartctl_device_capacity_bytes{instance=~\"$instance\", job=\"$job\"} * on(device, instance) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
+          "expr": "sum by (model_name) (smartctl_device_capacity_bytes{instance=~\"$instance\", job=\"$job\"} * on(device, juju_unit) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
           "legendFormat": "{{ model_name }}",
           "range": true,
           "instant": false,
@@ -2153,7 +2153,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (model_name) (smartctl_device_capacity_blocks{instance=~\"$instance\", job=\"$job\"} * on(device, instance) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
+          "expr": "sum by (model_name) (smartctl_device_capacity_blocks{instance=~\"$instance\", job=\"$job\"} * on(device, juju_unit) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
           "legendFormat": "{{ model_name }}",
           "range": true,
           "instant": false,
@@ -2238,7 +2238,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (model_name) (smartctl_device_bytes_written{instance=~\"$instance\", job=\"$job\"} * on(device, instance) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
+          "expr": "sum by (model_name) (smartctl_device_bytes_written{instance=~\"$instance\", job=\"$job\"} * on(device, juju_unit) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
           "legendFormat": "{{ model_name }}",
           "range": true,
           "instant": false,
@@ -2323,7 +2323,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (model_name) (smartctl_device_bytes_read{instance=~\"$instance\", job=\"$job\"} * on(device, instance) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
+          "expr": "sum by (model_name) (smartctl_device_bytes_read{instance=~\"$instance\", job=\"$job\"} * on(device, juju_unit) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
           "legendFormat": "{{ model_name }}",
           "range": true,
           "instant": false,
@@ -2408,7 +2408,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (model_name) (smartctl_device_block_size{instance=~\"$instance\", job=\"$job\",blocks_type=\"logical\"} * on(device, instance) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
+          "expr": "sum by (model_name) (smartctl_device_block_size{instance=~\"$instance\", job=\"$job\",blocks_type=\"logical\"} * on(device, juju_unit) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
           "legendFormat": "{{ model_name }}",
           "range": true,
           "instant": false,
@@ -2493,7 +2493,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (model_name) (smartctl_device_block_size{instance=~\"$instance\", job=\"$job\",blocks_type=\"physical\"} * on(device, instance) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
+          "expr": "sum by (model_name) (smartctl_device_block_size{instance=~\"$instance\", job=\"$job\",blocks_type=\"physical\"} * on(device, juju_unit) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
           "legendFormat": "{{ model_name }}",
           "range": true,
           "instant": false,
@@ -2578,7 +2578,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (model_name) (smartctl_device_available_spare_threshold{instance=~\"$instance\", job=\"$job\"} * on(device, instance) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
+          "expr": "sum by (model_name) (smartctl_device_available_spare_threshold{instance=~\"$instance\", job=\"$job\"} * on(device, juju_unit) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
           "legendFormat": "{{ model_name }}",
           "range": true,
           "instant": false,
@@ -2664,7 +2664,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (model_name) (smartctl_device_available_spare{instance=~\"$instance\", job=\"$job\"} * on(device, instance) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
+          "expr": "sum by (model_name) (smartctl_device_available_spare{instance=~\"$instance\", job=\"$job\"} * on(device, juju_unit) group_left(model_name) smartctl_device{instance=~\"$instance\"})",
           "legendFormat": "{{ model_name }}",
           "range": true,
           "instant": false,


### PR DESCRIPTION
Fixes: #367

The bug occurs because the `instance` label is always set to `localhost:10201`. If you have multiple hosts, there might be duplicate drive names coming from different hosts; and because the label is not unique, there will be conflicts during the joins for some Smartctl graphs. So it's better to use the `juju_unit` label which is guaranteed to be unique.  