### PR TITLE
Fire SmartHealthStatusFail only for physical devices

### DIFF
--- a/src/prometheus_alert_rules/smart.yaml
+++ b/src/prometheus_alert_rules/smart.yaml
@@ -33,6 +33,9 @@ groups:
           LABELS = {{ $labels }}
 
   - alert: SmartHealthStatusFail
+    # We can check if the physical size of the drive is 0, meaning it's a logical device,
+    # and ignore the status 0, which is always returned for logical devices, like HW RAID,
+    # avoiding false positives.
     expr: (smartctl_device_smart_status == 0) and on(device, juju_unit) (smartctl_device_block_size{blocks_type="physical"} != 0)
     for: 2m
     labels:

--- a/src/prometheus_alert_rules/smart.yaml
+++ b/src/prometheus_alert_rules/smart.yaml
@@ -33,7 +33,7 @@ groups:
           LABELS = {{ $labels }}
 
   - alert: SmartHealthStatusFail
-    expr: smartctl_device_smart_status == 0
+    expr: (smartctl_device_smart_status == 0) and on(device, juju_unit) (smartctl_device_block_size{blocks_type="physical"} != 0)
     for: 2m
     labels:
       severity: critical

--- a/tests/unit/test_alert_rules/test_smart.yaml
+++ b/tests/unit/test_alert_rules/test_smart.yaml
@@ -68,6 +68,8 @@ tests:
     input_series:
       - series: 'smartctl_device_smart_status{device="sda", instance="ubuntu-1"}'
         values: '0x15'
+      - series: 'smartctl_device_block_size{device="sda", instance="ubuntu-1", blocks_type="physical"}'
+        values: '1x15'
 
     alert_rule_test:
       - eval_time: 10m
@@ -83,6 +85,18 @@ tests:
                 SMART health status failed for device. This means either that the device has already failed, or that it is predicting its own failure within the next 24 hours.
                   VALUE = 0
                   LABELS = map[__name__:smartctl_device_smart_status device:sda instance:ubuntu-1]
+
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_device_smart_status{device="sda", instance="ubuntu-1"}'
+        values: '0x15'
+      - series: 'smartctl_device_block_size{device="sda", instance="ubuntu-1", blocks_type="physical"}'
+        values: '0x15'
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: SmartHealthStatusFail
+        exp_alerts: # alerts shouldn't fire since block size is 0
 
   - interval: 1m
     input_series:


### PR DESCRIPTION
Found a possible solution for the issue. The smartctl exporter has the following metrics:

```
smartctl_device_block_size{blocks_type="physical",device="sda"} 0
smartctl_device_block_size{blocks_type="logical",device="sda"} 512
```

We can check if the physical size of the drive is 0, meaning it's a logical device, and ignore 

```
smartctl_device_smart_status{device="sda"} == 0
````
Some context:

> The exporter doesn't distinguish between logical and physical block devices and exports metrics for anything listed by smartctl --scan

And there is no concrete way to determine that through the metrics.

Closes: #357