### PR TITLE
Pin urllib3 to support running on ubuntu@20.04

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,8 @@ distro
 ops >= 2.2.0
 jinja2
 redfish  # requests is included in this
+# workaround for https://github.com/urllib3/urllib3/blob/main/CHANGES.rst#230-2024-12-22, because
+# urllib3 build-on ubuntu@22.04 will not run-on ubuntu@20.04 (python 3.8.10)
+urllib3 < 2.3.0 # indirect dependency from redfish -> requests -> urllib3
 pydantic < 2
 git+https://github.com/canonical/prometheus-hardware-exporter.git


### PR DESCRIPTION
Pin `urllib3 < 2.3.0` to support running on ubuntu@20.04 because the latest urllib3 does not support Python 3.8 anymore: https://github.com/urllib3/urllib3/blob/main/CHANGES.rst#230-2024-12-22.

However, we should consider split the charm to build and run on the same environment.

Fix CI failure on ubuntu@20.04 base.