### PR TITLE
Avoid repeated restart DCGM snap service.

### DIFF
--- a/src/hw_tools.py
+++ b/src/hw_tools.py
@@ -252,7 +252,6 @@ class DCGMExporterStrategy(SnapStrategy):
         try:
             shutil.copy(self.metric_file, self.snap_common)
             self.snap_client.set({"dcgm-exporter-metrics-file": self.metric_file.name})
-            self.snap_client.restart(reload=True)
         except Exception as err:  # pylint: disable=broad-except
             logger.error("Failed to configure custom DCGM metrics: %s", err)
             raise err

--- a/tests/unit/test_hw_tools.py
+++ b/tests/unit/test_hw_tools.py
@@ -1214,7 +1214,6 @@ def test_dcgm_create_custom_metrics(dcgm_exporter_strategy, mock_shutil_copy, mo
     dcgm_exporter_strategy.snap_client.set.assert_called_once_with(
         {"dcgm-exporter-metrics-file": "dcgm_metrics.csv"}
     )
-    dcgm_exporter_strategy.snap_client.restart.assert_called_once_with(reload=True)
 
 
 def test_dcgm_create_custom_metrics_copy_fail(


### PR DESCRIPTION
The snap service will be restarted at the config_changed event, so it's not necessary to restart in the strategy class.

Closes: #384 