### PR TITLE
Include the latest/stable channel for grafana-agent on Noble

### DIFF
--- a/tests/functional/bundle.yaml.j2
+++ b/tests/functional/bundle.yaml.j2
@@ -16,11 +16,7 @@ applications:
       - "0"
   grafana-agent:
     charm: grafana-agent
-  {% if base == 'ubuntu@24.04' %}
-    channel: latest/candidate  # Note(rgildein): Right now, grafana-agent is not support for Noble on latest/stable. See #348
-  {% else %}
     channel: latest/stable
-  {% endif %}
   hardware-observer:
     charm: {{ charm }}
 


### PR DESCRIPTION
grafana-agent on Noble is available for amd64 but not on arm64 yet.

Partially Closes: #347