### PR TITLE
Func test fixes & improvements

### DIFF
--- a/tests/functional/test_charm.py
+++ b/tests/functional/test_charm.py
@@ -236,19 +236,6 @@ class TestCharmWithHW:
 
         await app.reset_config(["hardware-exporter-port"])
 
-    async def test_no_redfish_config(self, unit, ops_test, provided_collectors):
-        """Test that there is no Redfish options because it's not available on lxd machines."""
-        if "redfish" in provided_collectors:
-            pytest.skip("redfish in provided collectors, skipping test")
-
-        try:
-            config = await get_hardware_exporter_config(ops_test, unit.name)
-        except HardwareExporterConfigError:
-            pytest.fail("Not able to obtain hardware-exporter config!")
-        assert config.get("redfish_host") is None
-        assert config.get("redfish_username") is None
-        assert config.get("redfish_client_timeout") is None
-
     async def test_config_changed_log_level(self, app, unit, ops_test, provided_collectors):
         """Test changing the config option: exporter-log-level."""
         if not provided_collectors:

--- a/tests/functional/test_charm.py
+++ b/tests/functional/test_charm.py
@@ -239,6 +239,20 @@ class TestCharmWithHW:
 
         await app.reset_config(["hardware-exporter-port"])
 
+    async def test_smartctl_exporter_metrics(self, ops_test, app, unit):
+        """Test if smartctl exporter metrics are available."""
+        try:
+            # smartctl exporter runs on port 10201 (check config.yaml)
+            metrics = await get_generic_exporter_metrics(ops_test, unit.name, 10201, "smartctl")
+        except MetricsFetchError:
+            pytest.fail("Not able to obtain metrics!")
+
+        expected_metric_values = {
+            "smartctl_version": 1.0,
+        }
+        if not assert_metrics(metrics, expected_metric_values):
+            pytest.fail("Expected metrics not present!")
+
     async def test_config_changed_log_level(self, app, unit, ops_test, provided_collectors):
         """Test changing the config option: exporter-log-level."""
         if not provided_collectors:
@@ -417,20 +431,6 @@ class TestCharmWithHW:
         results = await run_command_on_unit(ops_test, unit.name, check_active_cmd)
         assert results.get("return-code") == 0
         assert results.get("stdout").strip() == "active"
-
-    async def test_smartctl_exporter_metrics(self, ops_test, app, unit):
-        """Test if smartctl exporter metrics are available."""
-        try:
-            # smartctl exporter runs on port 10201 (check config.yaml)
-            metrics = await get_generic_exporter_metrics(ops_test, unit.name, 10201, "smartctl")
-        except MetricsFetchError:
-            pytest.fail("Not able to obtain metrics!")
-
-        expected_metric_values = {
-            "smartctl_version": 1.0,
-        }
-        if not assert_metrics(metrics, expected_metric_values):
-            pytest.fail("Expected metrics not present!")
 
     async def test_dcgm_exporter_metrics(self, ops_test, app, unit, nvidia_present):
         """Test if dcgm exporter metrics are available."""

--- a/tests/functional/test_charm.py
+++ b/tests/functional/test_charm.py
@@ -753,9 +753,9 @@ async def test_on_remove_event(app, ops_test, nvidia_present):
         lambda: ops_test.model.applications[APP_NAME].status == "unknown"
     )
 
-    if assert_snap_installed(ops_test, principal_unit.name, "smartctl-exporter"):
+    if await assert_snap_installed(ops_test, principal_unit.name, "smartctl-exporter"):
         pytest.fail("smartctl-exporter snap has not been removed")
-    if nvidia_present and assert_snap_installed(ops_test, principal_unit.name, "dcgm"):
+    if nvidia_present and await assert_snap_installed(ops_test, principal_unit.name, "dcgm"):
         pytest.fail("dcgm snap has not been removed")
 
     cmd = "ls /etc/hardware-exporter-config.yaml"

--- a/tests/functional/test_charm.py
+++ b/tests/functional/test_charm.py
@@ -238,8 +238,8 @@ class TestCharmWithHW:
 
     async def test_no_redfish_config(self, unit, ops_test, provided_collectors):
         """Test that there is no Redfish options because it's not available on lxd machines."""
-        if not provided_collectors:
-            pytest.skip("No collectors provided, skipping test")
+        if "redfish" in provided_collectors:
+            pytest.skip("redfish in provided collectors, skipping test")
 
         try:
             config = await get_hardware_exporter_config(ops_test, unit.name)
@@ -375,7 +375,7 @@ class TestCharmWithHW:
             config = await get_hardware_exporter_config(ops_test, unit.name)
         except HardwareExporterConfigError:
             pytest.fail("Not able to obtain hardware-exporter config!")
-        assert config["redfish_client_timeout"] == int(new_timeout)
+        assert config["redfish_client_timeout"] == new_timeout
 
         await app.reset_config(["collect-timeout"])
 

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -1,5 +1,6 @@
 """Helper functions to run functional tests for hardware-observer."""
 
+import json
 import re
 from collections import defaultdict
 from dataclasses import dataclass
@@ -47,6 +48,12 @@ class MetricsFetchError(Exception):
 
 class HardwareExporterConfigError(Exception):
     """Raise if something goes wrong when getting hardware-exporter config."""
+
+    pass
+
+
+class SnapConfigError(Exception):
+    """Raise if something goes wrong when getting snap config."""
 
     pass
 
@@ -100,6 +107,15 @@ async def get_hardware_exporter_metrics(
         raise MetricsFetchError
     parsed_metrics = parse_hardware_exporter_metrics(results.get("stdout").strip())
     return parsed_metrics
+
+
+async def get_snap_config(ops_test, unit_name: str, snap_name: str) -> dict:
+    """Return snap config from unit."""
+    command = f"snap get {snap_name} -d"
+    results = await run_command_on_unit(ops_test, unit_name, command)
+    if results.get("return-code") > 0:
+        raise SnapConfigError
+    return json.loads(results.get("stdout"))
 
 
 async def assert_snap_installed(ops_test, unit_name: str, snap_name: str) -> bool:

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -85,7 +85,7 @@ async def get_generic_exporter_metrics(
 
     Raises MetricsFetchError if command to fetch metrics didn't execute successfully.
     """
-    command = f"curl -s localhost:{port}"
+    command = f"curl -s localhost:{port}/metrics"
     results = await run_command_on_unit(ops_test, unit_name, command)
     if results.get("return-code") > 0:
         raise MetricsFetchError

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -197,7 +197,7 @@ def parse_metrics(metrics_input: str) -> dict[str, list[Metric]]:
             parsed_metrics["ipmi_sel"].append(metric)
         elif name.startswith("ipmi"):
             parsed_metrics["ipmi_sensor"].append(metric)
-        elif name.startswith("poweredgeraid"):
+        elif name.startswith("poweredgeraid") or name.startswith("perccli"):
             parsed_metrics["poweredge_raid"].append(metric)
         elif name.startswith("megaraid") or name.startswith("storcli"):
             parsed_metrics["mega_raid"].append(metric)


### PR DESCRIPTION
Closes #405 

Additionally, adds the following func tests:

- Check for DCGM and Smartctl Exporters metrics
- Check for config-changed for Smartctl Exporter port
- Check if the snaps for the above exporters are removed on uninstall