### PR TITLE
Change protocol for HPE software repo from `http` to `https`

### DIFF
--- a/src/hw_tools.py
+++ b/src/hw_tools.py
@@ -371,7 +371,7 @@ class SSACLIStrategy(APTStrategyABC):
 
     _name = HWTool.SSACLI
     pkg = HWTool.SSACLI.value
-    repo_line = "deb http://downloads.linux.hpe.com/SDR/repo/mcp stretch/current non-free"
+    repo_line = "deb https://downloads.linux.hpe.com/SDR/repo/mcp stretch/current non-free"
 
     @property
     def repo(self) -> apt.DebianRepository:


### PR DESCRIPTION
Also see https://community.hpe.com/t5/operating-system-linux/linux-ubuntu-update-server-not-responding/m-p/7238924#M105438

Fixes: #414 