### PR TITLE
Correct logs files permissions & Redirect logs by storelib to other directory than /var/log/

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -163,12 +163,6 @@ class HardwareObserverCharm(ops.CharmBase):
                 self.model.unit.status = BlockedStatus(msg)
                 return
 
-        # Correct log permissions if storcli is detected
-        # Currently this is to deal with issue https://github.com/canonical/hardware-observer-operator/issues/424
-        # but later other tools may also need this for compliance with CIS Hardening benchmarks 
-        if HWTool.STORCLI in self.stored_tools:
-            self.hw_tool_helper.correct_log_permissions()
-
         self._on_update_status(event)
 
     def _on_remove(self, _: EventBase) -> None:
@@ -188,6 +182,13 @@ class HardwareObserverCharm(ops.CharmBase):
 
     def _on_update_status(self, _: EventBase) -> None:  # noqa: C901
         """Update the charm's status."""
+
+        # Correct log permissions if storcli is detected
+        # Currently this is to deal with issue https://github.com/canonical/hardware-observer-operator/issues/424
+        # but later other tools may also need this for compliance with CIS Hardening benchmarks
+        if HWTool.STORCLI in self.stored_tools:
+            self.hw_tool_helper.correct_log_permissions()
+
         if not self._stored.resource_installed:  # type: ignore[truthy-function]
             # The charm should be in BlockedStatus with install failed msg
             return  # type: ignore[unreachable]
@@ -237,12 +238,6 @@ class HardwareObserverCharm(ops.CharmBase):
             )
             event.defer()
             return
-
-        # Correct log permissions if storcli is detected
-        # Currently this is to deal with issue https://github.com/canonical/hardware-observer-operator/issues/424
-        # but later other tools may also need this for compliance with CIS Hardening benchmarks 
-        if HWTool.STORCLI in self.stored_tools:
-            self.hw_tool_helper.correct_log_permissions()
 
         if self.cos_agent_related:
             success, message = self.validate_configs()

--- a/src/charm.py
+++ b/src/charm.py
@@ -163,8 +163,11 @@ class HardwareObserverCharm(ops.CharmBase):
                 self.model.unit.status = BlockedStatus(msg)
                 return
 
-        # Correct log permissions
-        self.hw_tool_helper.correct_log_permissions()
+        # Correct log permissions if storcli is detected
+        # Currently this is to deal with issue https://github.com/canonical/hardware-observer-operator/issues/424
+        # but later other tools may also need this for compliance with CIS Hardening benchmarks 
+        if HWTool.STORCLI in self.stored_tools:
+            self.hw_tool_helper.correct_log_permissions()
 
         self._on_update_status(event)
 
@@ -235,8 +238,11 @@ class HardwareObserverCharm(ops.CharmBase):
             event.defer()
             return
 
-        # Correct log permissions
-        self.hw_tool_helper.correct_log_permissions()
+        # Correct log permissions if storcli is detected
+        # Currently this is to deal with issue https://github.com/canonical/hardware-observer-operator/issues/424
+        # but later other tools may also need this for compliance with CIS Hardening benchmarks 
+        if HWTool.STORCLI in self.stored_tools:
+            self.hw_tool_helper.correct_log_permissions()
 
         if self.cos_agent_related:
             success, message = self.validate_configs()

--- a/src/charm.py
+++ b/src/charm.py
@@ -163,6 +163,9 @@ class HardwareObserverCharm(ops.CharmBase):
                 self.model.unit.status = BlockedStatus(msg)
                 return
 
+        # Correct log permissions
+        self.hw_tool_helper.correct_log_permissions()
+
         self._on_update_status(event)
 
     def _on_remove(self, _: EventBase) -> None:
@@ -231,6 +234,9 @@ class HardwareObserverCharm(ops.CharmBase):
             )
             event.defer()
             return
+
+        # Correct log permissions
+        self.hw_tool_helper.correct_log_permissions()
 
         if self.cos_agent_related:
             success, message = self.validate_configs()

--- a/src/charm.py
+++ b/src/charm.py
@@ -182,12 +182,10 @@ class HardwareObserverCharm(ops.CharmBase):
 
     def _on_update_status(self, _: EventBase) -> None:  # noqa: C901
         """Update the charm's status."""
-
-        # Correct log permissions if storcli is detected
-        # Currently this is to deal with issue https://github.com/canonical/hardware-observer-operator/issues/424
-        # but later other tools may also need this for compliance with CIS Hardening benchmarks
-        if HWTool.STORCLI in self.stored_tools:
-            self.hw_tool_helper.correct_log_permissions()
+        # Correct log permissions to deal with issue
+        # https://github.com/canonical/hardware-observer-operator/issues/424
+        # if {HWTool.STORCLI, HWTool.PERCCLI} & self.stored_tools:
+        self.hw_tool_helper.correct_log_permissions()
 
         if not self._stored.resource_installed:  # type: ignore[truthy-function]
             # The charm should be in BlockedStatus with install failed msg

--- a/src/charm.py
+++ b/src/charm.py
@@ -182,9 +182,8 @@ class HardwareObserverCharm(ops.CharmBase):
 
     def _on_update_status(self, _: EventBase) -> None:  # noqa: C901
         """Update the charm's status."""
-        # Correct log permissions to deal with issue
+        # Correct log permissions in /var/log/ to deal with issue
         # https://github.com/canonical/hardware-observer-operator/issues/424
-        # if {HWTool.STORCLI, HWTool.PERCCLI} & self.stored_tools:
         self.hw_tool_helper.correct_log_permissions()
 
         if not self._stored.resource_installed:  # type: ignore[truthy-function]

--- a/src/hw_tools.py
+++ b/src/hw_tools.py
@@ -777,3 +777,65 @@ class HWToolHelper:
         if failed_checks:
             return False, f"Fail strategy checks: {failed_checks}"
         return True, ""
+
+    @staticmethod
+    def correct_log_permissions() -> None:
+        """Update permissions on log files to comply with CIS benchmarks.
+
+        Equivalent to the CIS remediation from issue
+        [#424](https://github.com/canonical/hardware-observer-operator/issues/424).
+        """
+        logger.info("Fixing permissions on log files to comply with CIS benchmarks")
+        try:
+
+            cmd = [
+                "find",
+                "/var/log/",
+                "-perm",
+                "/u+xs,g+xws,o+xwrt",
+                "!",
+                "-name",
+                "history.log*",
+                "!",
+                "-name",
+                "eipp.log.xz*",
+                "!",
+                "-name",
+                "[bw]tmp",
+                "!",
+                "-name",
+                "[bw]tmp.*",
+                "!",
+                "-name",
+                "[bw]tmp-*",
+                "!",
+                "-name",
+                "lastlog",
+                "!",
+                "-name",
+                "lastlog.*",
+                "!",
+                "-name",
+                "cloud-init.log*",
+                "!",
+                "-name",
+                "localmessages*",
+                "!",
+                "-name",
+                "waagent.log*",
+                "-type",
+                "f",
+                "-regextype",
+                "posix-extended",
+                "-regex",
+                ".*",
+                "-exec",
+                "chmod",
+                "u-xs,g-xws,o-xwrt",
+                "{}",
+                ";",
+            ]
+            subprocess.run(cmd, check=True)
+            logger.debug("Successfully correct log file permissions")
+        except subprocess.SubprocessError as e:
+            logger.error(f"Failed to correct log file permissions: {e}")


### PR DESCRIPTION
Closes #424

- **Description:**
    - `storelib` is a low-level library used as a backend for many storage controllers (storcli, perccli, megacli, sas3ircu, sas2ircu)
    - unwanted log files created by the underlying `storelib` library, not directly by controller tools: this is hardcoded behavior in the binary → the tools like `storcli` may be unaware of this behavior. That’s why we cannot change this behavior directly from the tool or its setup.
- **Solution:**
    - Use a `.ini`config file to change location of the logs by `storelib`
    - This config file is **undocumented officially**. It's likely based on reverse engineering, Broadcom support channels or community findings. There are concerns like:
        - Where to place?
        - Name of the `.ini` may varies depending on tools
        - Not all versions of `storelib` respect this config. Some vendor-locked or stripped-down binaries may **ignore custom config paths**.
- References
    - https://www.dell.com/community/en/conversations/poweredge-hddscsiraid/problem-using-linux-perccli-utility-for-all-dell-hbaperc-controllers/66c83e5058ef9a642bc62bec
    - https://forums.servethehome.com/index.php?resources/broadcom-lsi-avago-storcli-reference-user-guide.42/