### PR TITLE
Add base for hwo charm on terraform

### DIFF
--- a/tests/manual/etc/1_add_machine/main.tf
+++ b/tests/manual/etc/1_add_machine/main.tf
@@ -64,6 +64,7 @@ resource "juju_application" "hardware-observer" {
 
   charm {
     name    = "hardware-observer"
+    base = juju_machine.machine.base
     channel = "latest/stable"
   }
 }


### PR DESCRIPTION
I was running terraform in torchtusk using jammy. After cos was ready the job failed with:

> Unable to create integration, got error: cannot add relation
"grafana-agent:cos-agent hardware-observer:cos-agent": principal and subordinate applications' bases must match.

If base is not set, hwo deploys on noble and creates this issue. See the juju status

```
App                Version  Status   Scale  Charm              Channel        Rev  Exposed  Message
grafana-agent               active       1  grafana-agent      latest/stable  456  no       tracing: off
hardware-observer           blocked      0  hardware-observer  latest/stable  275  no       Missing relation: [cos-agent]
microk8s                    active       0  microk8s           1.28/stable    213  no       node is ready
ubuntu             22.04    active       1  ubuntu             latest/stable   25  no       

Unit                    Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*               active    idle   0        10.241.7.177           
  grafana-agent/0*      active    idle            10.241.7.177           tracing: off
  hardware-observer/0*  blocked   idle            10.241.7.177           Missing relation: [cos-agent]

Machine  State    Address       Inst id             Base          AZ  Message
0        started  10.241.7.177  manual:10.93.105.1  ubuntu@22.04      Manually provisioned machine
```

Note that rev `275` on hwo is for noble and that is why it creates this issue.

After this change it was possible to relate grafana-agent with hwo