### PR TITLE
Increase model wait time for terraform

### DIFF
--- a/tests/manual/scripts/wait-for-model.sh
+++ b/tests/manual/scripts/wait-for-model.sh
@@ -9,4 +9,4 @@ if [ -z "$MODEL" ]; then
     exit 1
 fi
 
-juju wait-for model $MODEL --query='forEach(applications, app => app.status == "active")'
+juju wait-for model $MODEL --timeout=20m0s --query='forEach(applications, app => app.status == "active")'


### PR DESCRIPTION
Traefik sometimes is taking more time than the default timeout. Increasing the default timeout solves the issue