### PR TITLE
CollectorFailed: Reduce check frequency

### DIFF
--- a/.github/workflows/test_prometheus_rules.yaml
+++ b/.github/workflows/test_prometheus_rules.yaml
@@ -23,7 +23,7 @@ jobs:
 
       # prometheus snap includes promtool
       - name: Install prometheus snap
-        run: sudo snap install prometheus --channel=2/candidate
+        run: sudo snap install prometheus
 
       - name: Check validity of prometheus alert rules
         run: |

--- a/.github/workflows/test_prometheus_rules.yaml
+++ b/.github/workflows/test_prometheus_rules.yaml
@@ -23,7 +23,7 @@ jobs:
 
       # prometheus snap includes promtool
       - name: Install prometheus snap
-        run: sudo snap install prometheus
+        run: sudo snap install prometheus --channel=2/candidate
 
       - name: Check validity of prometheus alert rules
         run: |

--- a/src/prometheus_alert_rules/general.yaml
+++ b/src/prometheus_alert_rules/general.yaml
@@ -4,7 +4,6 @@ groups:
     - alert: CollectorFailed
       expr: '{__name__=~"(.*)_collector_failed"} == 1'
       for: 5m
-      keep_firing_for: 5m
       labels:
         severity: error
       annotations:

--- a/src/prometheus_alert_rules/general.yaml
+++ b/src/prometheus_alert_rules/general.yaml
@@ -3,7 +3,8 @@ groups:
   rules:
     - alert: CollectorFailed
       expr: '{__name__=~"(.*)_collector_failed"} == 1'
-      for: 1m
+      for: 5m
+      keep_firing_for: 5m
       labels:
         severity: error
       annotations:

--- a/tests/unit/test_alert_rules/test_general.yaml
+++ b/tests/unit/test_alert_rules/test_general.yaml
@@ -12,7 +12,7 @@ tests:
         values: '1x15'
 
     alert_rule_test:
-      - eval_time: 2m
+      - eval_time: 6m
         alertname: CollectorFailed
         exp_alerts:
           - exp_labels:


### PR DESCRIPTION
Closes #438  

Increase the `for` duration of `CollectorFailed` alert from `1m` to `5m`. 
If real hardware issues occurs during that increased monitoring gap, HWO will still be able to detect them when monitoring resumes, given hardware metrics still immediately reflect the issue and barely no hardware failure resolves itself in minutes.

Also add a `keep_firing_for` duration to keep the alert firing to prevent flapping issue.

Update: `keep_firing_for` only supported from Prometheus 2.42+ which is newer than Prometheus snap in stable channel. Maybe use newer Prometheus, or remove it.
- [Charm Prometheus](https://charmhub.io/prometheus-k8s) uses the latest version of the [canonical/prometheus](https://ghcr.io/canonical/prometheus) image, which deploys Prometheus 2.46. 
- Remove `keep_firing_for` after discussion.