### PR TITLE
Enhance manual tests for `eevee` and `kongfu`

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -48,6 +48,7 @@ def pytest_addoption(parser):
             "poweredge_raid",
             "lsi_sas_2",
             "lsi_sas_3",
+            "hpe_ssa",
         ],
         help="Provide space-separated list of collectors for testing with real hardware.",
     )

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -265,4 +265,6 @@ def parse_hardware_exporter_metrics(metrics_input: str) -> dict[str, list[Metric
             parsed_metrics["poweredge_raid"].append(metric)
         elif name.startswith("megaraid") or name.startswith("storcli"):
             parsed_metrics["mega_raid"].append(metric)
+        elif name.startswith("ssacli"):
+            parsed_metrics["hpe_ssa"].append(metric)
     return parsed_metrics

--- a/tests/manual/jobs/eevee/README.md
+++ b/tests/manual/jobs/eevee/README.md
@@ -15,3 +15,17 @@
 - [x] Smartctl Exporter (require S.M.A.R.T disks)
   - [x] smartctl
 
+## Running the tests
+
+You can run the functional tests for real hardware by following these steps:
+
+```shell
+# Adding relation will be tested as part of the test case, so we need to remove it before running the tests
+juju -m hw-obs remove-relation hardware-observer grafana-agent
+
+# We don't have redfish credential for this machine
+juju -m hw-obs config hardware-observer redfish-disable=true
+
+# Running the tests
+tox -e func -- -v --realhw --model hw-obs --no-deploy  --collectors ipmi_dcmi ipmi_sel ipmi_sensor hpe_ssa  --keep-models
+```

--- a/tests/manual/jobs/eevee/README.md
+++ b/tests/manual/jobs/eevee/README.md
@@ -21,10 +21,10 @@ You can run the functional tests for real hardware by following these steps:
 
 ```shell
 # Adding relation will be tested as part of the test case, so we need to remove it before running the tests
-juju -m hw-obs remove-relation hardware-observer grafana-agent
+juju remove-relation -m hw-obs hardware-observer grafana-agent
 
 # We don't have redfish credential for this machine
-juju -m hw-obs config hardware-observer redfish-disable=true
+juju config -m hw-obs hardware-observer redfish-disable=true
 
 # Running the tests
 tox -e func -- -v --realhw --model hw-obs --no-deploy  --collectors ipmi_dcmi ipmi_sel ipmi_sensor hpe_ssa  --keep-models

--- a/tests/manual/jobs/kongfu/README.md
+++ b/tests/manual/jobs/kongfu/README.md
@@ -24,3 +24,18 @@ the resource, you can attach the resource using
 ```shell
 juju attach-resource hardware-observer storcli-deb=<PATH-TO-STORCLI-DEB>
 ```
+
+## Running the tests
+
+You can run the functional tests for real hardware by following these steps:
+
+```shell
+# Adding relation will be tested as part of the test case, so we need to remove it before running the tests
+juju -m hw-obs remove-relation hardware-observer grafana-agent
+
+# We don't have redfish credential for this machine
+juju -m hw-obs config hardware-observer redfish-disable=true
+
+# Running the tests
+tox -e func -- -v --realhw --model hw-obs --no-deploy  --collectors ipmi_dcmi ipmi_sel ipmi_sensor mega_raid  --keep-models
+```

--- a/tests/manual/jobs/kongfu/README.md
+++ b/tests/manual/jobs/kongfu/README.md
@@ -31,10 +31,10 @@ You can run the functional tests for real hardware by following these steps:
 
 ```shell
 # Adding relation will be tested as part of the test case, so we need to remove it before running the tests
-juju -m hw-obs remove-relation hardware-observer grafana-agent
+juju remove-relation -m hw-obs hardware-observer grafana-agent
 
 # We don't have redfish credential for this machine
-juju -m hw-obs config hardware-observer redfish-disable=true
+juju config -m hw-obs hardware-observer redfish-disable=true
 
 # Running the tests
 tox -e func -- -v --realhw --model hw-obs --no-deploy  --collectors ipmi_dcmi ipmi_sel ipmi_sensor mega_raid  --keep-models

--- a/tests/manual/jobs/kongfu/README.md
+++ b/tests/manual/jobs/kongfu/README.md
@@ -36,6 +36,6 @@ juju remove-relation -m hw-obs hardware-observer grafana-agent
 # We don't have redfish credential for this machine
 juju config -m hw-obs hardware-observer redfish-disable=true
 
-# Running the tests
-tox -e func -- -v --realhw --model hw-obs --no-deploy  --collectors ipmi_dcmi ipmi_sel ipmi_sensor mega_raid  --keep-models
+# If you already attach the `storcli-deb` resource
+tox -e func -- -v -k 'not test_required_resources' --realhw --model hw-obs --no-deploy  --collectors ipmi_dcmi ipmi_sel ipmi_sensor mega_raid  --keep-models
 ```

--- a/tests/manual/scripts/bootstrap.sh
+++ b/tests/manual/scripts/bootstrap.sh
@@ -7,6 +7,7 @@ sudo apt update
 # Set up packages
 sudo snap install juju
 sudo snap install terraform --classic
+sudo snap install charmcraft --classic
 sudo apt-get install tox jq ubuntu-drivers-common -y
 
 # Download terragrunt


### PR DESCRIPTION
- Fix some problems in realhw tests
  - `hpe_ssa` collector is missing
- Add instruction on how to run realhw tests in `eevee` and `kongfu`