### PR TITLE
Update some setting for manual tests

### DIFF
--- a/tests/manual/etc/3_deploy_cos/main.tf
+++ b/tests/manual/etc/3_deploy_cos/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     juju = {
-      version = "~> 0.17.0"
+      version = "~> 0.20.0"
       source  = "juju/juju"
     }
   }
@@ -24,6 +24,13 @@ module "cos-lite-terraform" {
   config = {
     workload-storage = "microk8s-hostpath"
   }
+
+  # Add some temporary overrides, can remove when these channels are updated to latest/stable
+  alertmanager-channel = "1/stable"
+  prometheus-channel = "1/stable"
+  grafana-channel = "1/stable"
+  catalogue-channel = "1/stable"
+  loki-channel = "1/stable"
 }
 
 resource "juju_application" "metallb" {

--- a/tests/manual/etc/4_deploy_grafana_agent/main.tf
+++ b/tests/manual/etc/4_deploy_grafana_agent/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     juju = {
-      version = "~> 0.17.0"
+      version = "~> 0.20.0"
       source  = "juju/juju"
     }
   }
@@ -13,7 +13,7 @@ module "grafana-agent" {
   source = "git::https://github.com/canonical/snap-openstack.git//sunbeam-python/sunbeam/features/observability/etc/deploy-grafana-agent"
 
   grafana-agent-base             = var.grafana_agent_base
-  grafana-agent-channel          = "latest/stable"
+  grafana-agent-channel          = "1/stable" # Can move back to latest/stable when the charm is updated
   principal-application-model    = var.machine_model
   receive-remote-write-offer-url = var.receive-remote-write-offer-url
   grafana-dashboard-offer-url    = var.grafana-dashboard-offer-url


### PR DESCRIPTION
- Update juju terraform provider for cos & grafana-agent deployments to 0.20.0 to fix this error:
```
    │ Error: Failed to query available provider packages
    │ Could not retrieve the list of available versions for provider juju/juju:
    │ no available releases match the given constraints ~> 0.17.0, 0.20.0
```
, from corresponding Sunbeam's commit: https://github.com/canonical/snap-openstack/commit/544fb29f4907b4997a7c37aabe16195ce3e94262
- Change some charm channels to `1/stable` instead of `latest/stable` to fix: 
```
| STDERR [etc/3_deploy_cos] terraform: │ Unable to create application, got error: selecting releases: charm or bundle not found for channel "latest/stable", base "amd64/ubuntu/20.04/stable"
```