### PR TITLE
Remove Protobuf constraint for functional tests

### DIFF
--- a/tests/functional/requirements.txt
+++ b/tests/functional/requirements.txt
@@ -1,8 +1,6 @@
 async-lru
 pytest
 pytest-operator
-# Keep protobuf < 4.0 until macaroonbakery solves its incompatibility
-# https://github.com/go-macaroon-bakery/py-macaroon-bakery/issues/94
-protobuf<4.0
+protobuf
 tenacity
 pydantic < 2


### PR DESCRIPTION
As the [compatibility issue](https://github.com/canonical/hardware-observer-operator/security/dependabot/1) is fixed now, remove the constraint on `protobuf` to address this [vulnerability issue](https://github.com/canonical/hardware-observer-operator/security/dependabot/1)