### PR TITLE
Use requirements for prometheus-hardware-exporter pinning the tag

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ ops >= 2.2.0
 jinja2
 redfish  # requests is included in this
 pydantic < 2
-git+https://github.com/canonical/prometheus-hardware-exporter.git
+git+https://github.com/canonical/prometheus-hardware-exporter.git@v1.0.0#egg=prometheus-hardware-exporter


### PR DESCRIPTION
To have reproducible builds it's important to pin the exporter