### PR TITLE
Correct behavior when setting collect-timeout

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -299,9 +299,8 @@ class HardwareObserverCharm(ops.CharmBase):
         """Generate the scrape config as needed."""
         # Setting scrape_timeout as collect_timeout in the `duration` format specified in
         # https://prometheus.io/docs/prometheus/latest/configuration/configuration/#duration
-        scrape_config: List[Dict[str, Any]] = [
-            {"scrape_timeout": f"{self.model.config['collect-timeout']}s"}
-        ]
+        scrape_config: List[Dict[str, Any]] = []
+        timeout = f"{self.model.config['collect-timeout']}s"
 
         for exporter in self.exporters:
             if isinstance(exporter, HardwareExporter):
@@ -310,6 +309,7 @@ class HardwareObserverCharm(ops.CharmBase):
                     {
                         "metrics_path": "/metrics",
                         "static_configs": [{"targets": [f"localhost:{port}"]}],
+                        "scrape_timeout": timeout,
                     }
                 )
             if isinstance(exporter, SmartCtlExporter):
@@ -318,6 +318,7 @@ class HardwareObserverCharm(ops.CharmBase):
                     {
                         "metrics_path": "/metrics",
                         "static_configs": [{"targets": [f"localhost:{port}"]}],
+                        "scrape_timeout": timeout,
                     }
                 )
             if isinstance(exporter, DCGMExporter):
@@ -326,6 +327,7 @@ class HardwareObserverCharm(ops.CharmBase):
                     {
                         "metrics_path": "/metrics",
                         "static_configs": [{"targets": [f"localhost:{port}"]}],
+                        "scrape_timeout": timeout,
                     }
                 )
         return scrape_config

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -822,10 +822,21 @@ class TestCharm(unittest.TestCase):
         mock_exporters.return_value = [hw_exporter, smartctl_exporter, dcgm_exporter]
 
         assert self.harness.charm._scrape_config() == [
-            {"scrape_timeout": "10s"},
-            {"metrics_path": "/metrics", "static_configs": [{"targets": ["localhost:10200"]}]},
-            {"metrics_path": "/metrics", "static_configs": [{"targets": ["localhost:10201"]}]},
-            {"metrics_path": "/metrics", "static_configs": [{"targets": ["localhost:9400"]}]},
+            {
+                "metrics_path": "/metrics",
+                "static_configs": [{"targets": ["localhost:10200"]}],
+                "scrape_timeout": "10s",
+            },
+            {
+                "metrics_path": "/metrics",
+                "static_configs": [{"targets": ["localhost:10201"]}],
+                "scrape_timeout": "10s",
+            },
+            {
+                "metrics_path": "/metrics",
+                "static_configs": [{"targets": ["localhost:9400"]}],
+                "scrape_timeout": "10s",
+            },
         ]
 
     @mock.patch("charm.HardwareObserverCharm.exporters", new_callable=mock.PropertyMock)
@@ -841,8 +852,11 @@ class TestCharm(unittest.TestCase):
         mock_exporters.return_value = [smartctl_exporter]
 
         assert self.harness.charm._scrape_config() == [
-            {"scrape_timeout": "10s"},
-            {"metrics_path": "/metrics", "static_configs": [{"targets": ["localhost:10201"]}]},
+            {
+                "metrics_path": "/metrics",
+                "static_configs": [{"targets": ["localhost:10201"]}],
+                "scrape_timeout": "10s",
+            },
         ]
 
     @mock.patch("service.get_bmc_address")


### PR DESCRIPTION
Fixes canonical/prometheus-hardware-exporter#102
As shown from the issue, the current `_scrape_config()` makes grafana-agent create a ghost job (`hardware-observer_0_default`) doing nothing, and the `collect-timeout` config is set to this job but not for other real jobs. So when a new `collect-timeout` is set, grafana-agent only updates `scrape_timeout` for the ghost job, and Prometheus will still give up scrapping after 10s (default by grafana-agent) for other real jobs. 

This fix removes the ghost job and add the scrape timeout for each job. The expected configuration will be:
```
    scrape_configs:
    - job_name: hardware-observer_0_default
      metrics_path: /metrics
      scrape_timeout: 50s
      static_configs:
      - labels:
          juju_application: hardware-observer
          juju_model: hw-obs
          juju_model_uuid: 21e007d7-01b9-4cb0-884f-d6637c82cebf
          juju_unit: hardware-observer/0
        targets:
        - localhost:10200
```
