### PR TITLE
Add alert rules for missing IPMI metrics

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -107,7 +107,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [[ubuntu-24.04], [Ubuntu_ARM64_4C_16G_01], [self-hosted, linux, s390x],[self-hosted, ppc64el]]
+        runs-on: [[ubuntu-24.04], [ubuntu-24.04-arm], [self-hosted, linux, s390x],[self-hosted, ppc64el]]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -144,7 +144,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [[ubuntu-24.04], [Ubuntu_ARM64_4C_16G_01]]
+        runs-on: [[ubuntu-24.04], [ubuntu-24.04-arm]]
         test-command: ['tox -e func -- -v --base ubuntu@20.04 --keep-models', 'tox -e func -- -v --base ubuntu@22.04 --keep-models', 'tox -e func -- -v --base ubuntu@24.04 --keep-models' ]
         juju-channel: ["3.6/stable"]
     steps:

--- a/src/prometheus_alert_rules/ipmi_dcmi.yaml
+++ b/src/prometheus_alert_rules/ipmi_dcmi.yaml
@@ -1,6 +1,16 @@
 groups:
 - name: IpmiDcmi
   rules:
+    - alert: IPMIDCMICommandSuccessMetricsMissing
+      expr: absent_over_time(ipmi_dcmi_command_success[5m])
+      labels:
+        severity: critical
+      annotations:
+        summary: IPMI DCMI command success metrics missing. (instance {{ $labels.instance }})
+        description: |
+          The ipmi_dcmi_command_success metric has been missing for over 5 minutes.
+          This may indicate IPMI DCMI command timeouts.
+            LABELS = {{ $labels }}
 
     - alert: IPMIDCMICommandFailed
       expr: ipmi_dcmi_command_success == 0

--- a/src/prometheus_alert_rules/ipmi_dcmi.yaml
+++ b/src/prometheus_alert_rules/ipmi_dcmi.yaml
@@ -9,7 +9,7 @@ groups:
         summary: IPMI DCMI command success metrics missing. (instance {{ $labels.instance }})
         description: |
           The ipmi_dcmi_command_success metric has been missing for over 5 minutes.
-          This may indicate IPMI DCMI command timeouts.
+          This may indicate IPMI DCMI command timeouts, or that IPMI tools/services are not installed or supported on this hardware.
             LABELS = {{ $labels }}
 
     - alert: IPMIDCMICommandFailed

--- a/src/prometheus_alert_rules/ipmi_sel.yaml
+++ b/src/prometheus_alert_rules/ipmi_sel.yaml
@@ -1,6 +1,17 @@
 groups:
 - name: IpmiSel
   rules:
+    - alert: IPMISELCommandSuccessMetricsMissing
+      expr: absent_over_time(ipmi_sel_command_success[5m])
+      labels:
+        severity: critical
+      annotations:
+        summary: IPMI SEL command success metrics missing. (instance {{ $labels.instance }})
+        description: |
+          The ipmi_sel_command_success metric has been missing for over 5 minutes.
+          This may indicate IPMI SEL command timeouts.
+            LABELS = {{ $labels }}
+
     - alert: IPMISELCommandFailed
       expr: ipmi_sel_command_success == 0
       for: 5m
@@ -12,6 +23,7 @@ groups:
           Failed to get system event logs using ipmi-sel.
             VALUE = {{ $value }}
             LABELS = {{ $labels }}
+
     - alert: IPMISELStateWarning
       expr: ipmi_sel_state_warning > 0
       labels:
@@ -23,6 +35,7 @@ groups:
           IPMI SEL entry in warning state.
             LABELS = {{ $labels }}
             EVENT_ID = {{ $value }}
+
     - alert: IPMISELStateCritical
       expr: ipmi_sel_state_critical > 0
       labels:
@@ -34,6 +47,7 @@ groups:
           IPMI SEL entry in critical state.
             LABELS = {{ $labels }}
             EVENT_ID = {{ $value }}
+
     - alert: IPMISELDStateWarning
       expr: node_systemd_unit_state{name="ipmiseld.service", state=~"failed|inactive"} == 1
       for: 5m

--- a/src/prometheus_alert_rules/ipmi_sel.yaml
+++ b/src/prometheus_alert_rules/ipmi_sel.yaml
@@ -9,7 +9,7 @@ groups:
         summary: IPMI SEL command success metrics missing. (instance {{ $labels.instance }})
         description: |
           The ipmi_sel_command_success metric has been missing for over 5 minutes.
-          This may indicate IPMI SEL command timeouts.
+          This may indicate IPMI SEL command timeouts, or that IPMI tools/services are not installed or supported on this hardware.
             LABELS = {{ $labels }}
 
     - alert: IPMISELCommandFailed

--- a/src/prometheus_alert_rules/ipmi_sensors.yaml
+++ b/src/prometheus_alert_rules/ipmi_sensors.yaml
@@ -9,7 +9,7 @@ groups:
         summary: IPMI monitoring command success metrics missing. (instance {{ $labels.instance }})
         description: |
           The ipmimonitoring_command_success metric has been missing for over 5 minutes.
-          This may indicate IPMI monitoring command timeouts.
+          This may indicate IPMI monitoring command timeouts, or that IPMI tools/services are not installed or supported on this hardware.
             LABELS = {{ $labels }}
 
     - alert: IPMIMonitoringCommandFailed

--- a/src/prometheus_alert_rules/ipmi_sensors.yaml
+++ b/src/prometheus_alert_rules/ipmi_sensors.yaml
@@ -1,6 +1,16 @@
 groups:
 - name: IpmiSensors
   rules:
+    - alert: IPMIMonitoringCommandSuccessMetricsMissing
+      expr: absent_over_time(ipmimonitoring_command_success[5m])
+      labels:
+        severity: critical
+      annotations:
+        summary: IPMI monitoring command success metrics missing. (instance {{ $labels.instance }})
+        description: |
+          The ipmimonitoring_command_success metric has been missing for over 5 minutes.
+          This may indicate IPMI monitoring command timeouts.
+            LABELS = {{ $labels }}
 
     - alert: IPMIMonitoringCommandFailed
       expr: ipmimonitoring_command_success == 0
@@ -17,7 +27,7 @@ groups:
     - alert: IPMITemperatureStateNotOk
       expr: ipmi_temperature_celsius{state=~"Warning|Critical"}
       for: 5m
-      labels: 
+      labels:
         severity: "{{ toLower $labels.state }}"
       annotations:
         summary: Temperature in {{ toLower $labels.state }} state. (instance {{ $labels.instance }})
@@ -29,7 +39,7 @@ groups:
     - alert: IPMIPowerStateNotOk
       expr: ipmi_power_watts{state=~"Warning|Critical"}
       for: 5m
-      labels: 
+      labels:
         severity: "{{ toLower $labels.state }}"
       annotations:
         summary: Power in {{ toLower $labels.state }} state. (instance {{ $labels.instance }})
@@ -41,7 +51,7 @@ groups:
     - alert: IPMIVoltageStateNotOk
       expr: ipmi_voltage_volts{state=~"Warning|Critical"}
       for: 5m
-      labels: 
+      labels:
         severity: "{{ toLower $labels.state }}"
       annotations:
         summary: Voltage in {{ toLower $labels.state }} state. (instance {{ $labels.instance }})
@@ -53,7 +63,7 @@ groups:
     - alert: IPMICurrentStateNotOk
       expr: ipmi_current_amperes{state=~"Warning|Critical"}
       for: 5m
-      labels: 
+      labels:
         severity: "{{ toLower $labels.state }}"
       annotations:
         summary: Current in {{ toLower $labels.state }} state. (instance {{ $labels.instance }})
@@ -65,7 +75,7 @@ groups:
     - alert: IPMIFanSpeedStateNotOk
       expr: ipmi_fan_speed_rpm{state=~"Warning|Critical"}
       for: 5m
-      labels: 
+      labels:
         severity: "{{ toLower $labels.state }}"
       annotations:
         summary: Fan speed in {{ toLower $labels.state }} state. (instance {{ $labels.instance }})

--- a/tests/unit/test_alert_rules/test_ipmi_dcmi.yaml
+++ b/tests/unit/test_alert_rules/test_ipmi_dcmi.yaml
@@ -61,5 +61,5 @@ tests:
               summary: IPMI DCMI command success metrics missing. (instance )
               description: |
                 The ipmi_dcmi_command_success metric has been missing for over 5 minutes.
-                This may indicate IPMI DCMI command timeouts.
+                This may indicate IPMI DCMI command timeouts, or that IPMI tools/services are not installed or supported on this hardware.
                   LABELS = map[]

--- a/tests/unit/test_alert_rules/test_ipmi_dcmi.yaml
+++ b/tests/unit/test_alert_rules/test_ipmi_dcmi.yaml
@@ -45,3 +45,21 @@ tests:
                 IPMI DCMI power consumption percentage is high for over 5 minutes.
                   POWER_CONSUMPTION_PERCENTAGE = 0.85
                   LABELS = map[__name__:ipmi_dcmi_power_consumption_percentage instance:ubuntu-2]
+
+  - interval: 1m
+    input_series:
+      - series: some_other_metric{instance="ubuntu-0"}
+        values: '1x10'
+
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: IPMIDCMICommandSuccessMetricsMissing
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+            exp_annotations:
+              summary: IPMI DCMI command success metrics missing. (instance )
+              description: |
+                The ipmi_dcmi_command_success metric has been missing for over 5 minutes.
+                This may indicate IPMI DCMI command timeouts.
+                  LABELS = map[]

--- a/tests/unit/test_alert_rules/test_ipmi_sel.yaml
+++ b/tests/unit/test_alert_rules/test_ipmi_sel.yaml
@@ -142,5 +142,5 @@ tests:
               summary: IPMI SEL command success metrics missing. (instance )
               description: |
                 The ipmi_sel_command_success metric has been missing for over 5 minutes.
-                This may indicate IPMI SEL command timeouts.
+                This may indicate IPMI SEL command timeouts, or that IPMI tools/services are not installed or supported on this hardware.
                   LABELS = map[]

--- a/tests/unit/test_alert_rules/test_ipmi_sel.yaml
+++ b/tests/unit/test_alert_rules/test_ipmi_sel.yaml
@@ -126,3 +126,21 @@ tests:
                 The ipmiseld service is not active, indicating a potential problem.
                   VALUE = 1
                   LABELS = map[__name__:node_systemd_unit_state instance:ubuntu-4 name:ipmiseld.service state:inactive]
+
+  - interval: 1m
+    input_series:
+      - series: some_other_metric{instance="ubuntu-0"}
+        values: '1x10'
+
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: IPMISELCommandSuccessMetricsMissing
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+            exp_annotations:
+              summary: IPMI SEL command success metrics missing. (instance )
+              description: |
+                The ipmi_sel_command_success metric has been missing for over 5 minutes.
+                This may indicate IPMI SEL command timeouts.
+                  LABELS = map[]

--- a/tests/unit/test_alert_rules/test_ipmi_sensors.yaml
+++ b/tests/unit/test_alert_rules/test_ipmi_sensors.yaml
@@ -259,5 +259,5 @@ tests:
               summary: IPMI monitoring command success metrics missing. (instance )
               description: |
                 The ipmimonitoring_command_success metric has been missing for over 5 minutes.
-                This may indicate IPMI monitoring command timeouts.
+                This may indicate IPMI monitoring command timeouts, or that IPMI tools/services are not installed or supported on this hardware.
                   LABELS = map[]

--- a/tests/unit/test_alert_rules/test_ipmi_sensors.yaml
+++ b/tests/unit/test_alert_rules/test_ipmi_sensors.yaml
@@ -243,3 +243,21 @@ tests:
                 A sensor value, recorded by ipmi sensor, in critical state. Entity Presence and Slot Connector sensors are ignored.
                   VALUE = 50
                   LABELS = map[__name__:ipmi_generic_sensor_value instance:ubuntu-12 state:Critical]
+
+  - interval: 1m
+    input_series:
+      - series: some_other_metric{instance="ubuntu-0"}
+        values: '1x10'
+
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: IPMIMonitoringCommandSuccessMetricsMissing
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+            exp_annotations:
+              summary: IPMI monitoring command success metrics missing. (instance )
+              description: |
+                The ipmimonitoring_command_success metric has been missing for over 5 minutes.
+                This may indicate IPMI monitoring command timeouts.
+                  LABELS = map[]


### PR DESCRIPTION
Partially address https://github.com/canonical/prometheus-hardware-exporter/issues/101

Due to timeout issue, Prometheus may stop looking for the IPMI metrics before the exporter can export them, so these metrics won't appear in Prometheus. This PR adds rules checking whether the metric for IPMI commands has been exported (either the commands failed or success) to notify users in case IPMI metrics has disappeared for a while in Prometheus. 

If these alerts are firing, it could be a hint for the timeout issue, and probably increasing `collect-timeout` in charm config may help (already fixed in #455). 