### PR TITLE
Change default bind address for smartctl exporter

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 from pydantic import BaseModel  # pylint: disable = no-name-in-module
 
+DEFAULT_BIND_ADDRESS = "127.0.0.1"
+
 
 class ExporterSettings(BaseModel):  # pylint: disable = too-few-public-methods
     """Constant settings common across exporters."""

--- a/src/service.py
+++ b/src/service.py
@@ -15,6 +15,7 @@ from redfish import redfish_client
 from redfish.rest.v1 import InvalidCredentialsError
 
 from config import (
+    DEFAULT_BIND_ADDRESS,
     HARDWARE_EXPORTER_COLLECTOR_MAPPING,
     HARDWARE_EXPORTER_SETTINGS,
     ExporterSettings,
@@ -462,7 +463,7 @@ class SmartCtlExporter(SnapExporter):
         return super().configure() and self.set(
             {
                 "log.level": self.log_level.lower(),
-                "web.listen-address": f":{self.port}",
+                "web.listen-address": f"{DEFAULT_BIND_ADDRESS}:{self.port}",
             }
         )
 


### PR DESCRIPTION
Set the default bind address to 127.0.0.1 for smartctl exporter.

Closes: #460 