### PR TITLE
Fix RedfishStorageDriveHealthNotOk

### DIFF
--- a/src/prometheus_alert_rules_dynamic/redfish.yaml
+++ b/src/prometheus_alert_rules_dynamic/redfish.yaml
@@ -71,7 +71,7 @@ groups:
               LABELS = {{ $labels }}
 
       - alert: RedfishStorageDriveHealthNotOk
-        expr: redfish_storage_drive_info{health!~"OK|NA"}
+        expr: redfish_storage_drive_info{health!~"OK|NA", state="Enabled"}
         for: 5m
         labels:
           severity: critical

--- a/tests/unit/test_alert_rules/test_redfish.yaml
+++ b/tests/unit/test_alert_rules/test_redfish.yaml
@@ -130,7 +130,7 @@ tests:
 
   - interval: 1m
     input_series:
-      - series: redfish_storage_drive_info{instance="ubuntu-1", health="Unhealthy", system_id="s1", storage_id="stor1", drive_id="dr1"}
+      - series: redfish_storage_drive_info{instance="ubuntu-1", health="Unhealthy", system_id="s1", state="Enabled", storage_id="stor1", drive_id="dr1"}
         values: "1x15"
 
     alert_rule_test:
@@ -144,11 +144,13 @@ tests:
               system_id: s1
               storage_id: stor1
               drive_id: dr1
+              state: Enabled
             exp_annotations:
               summary: Redfish storage drive health not OK. (instance ubuntu-1)
               description: |
                 Redfish storage drive health not OK.
-                  LABELS = map[__name__:redfish_storage_drive_info drive_id:dr1 health:Unhealthy instance:ubuntu-1 storage_id:stor1 system_id:s1]
+                  LABELS = map[__name__:redfish_storage_drive_info drive_id:dr1 health:Unhealthy instance:ubuntu-1 state:Enabled storage_id:stor1 system_id:s1]
+
 
   - interval: 1m
     input_series:


### PR DESCRIPTION
If disks are disabled, it doesn't make sense to trigger alerts abouth their health.

Closes: [#113](https://github.com/canonical/prometheus-hardware-exporter/issues/113)