### PR TITLE
fix: BMC dashboard

### DIFF
--- a/src/dashboards_hardware_exporter/BMC.json
+++ b/src/dashboards_hardware_exporter/BMC.json
@@ -250,7 +250,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "{instance=\"$instance_var\"} |~ \"ipmiseld\\\\[\\\\d+\\\\]\" | pattern `<raw>\"<_>\"` | regexp `(?P<log_time>\\w+\\s*\\d{1,2} \\d+:\\d+:\\d+) (?P<host>.+?) (?P<pid>\\S+): (SEL System Event: (?P<bmc_time>\\w{3}-\\d{2}-\\d{4}, \\d{2}:\\d{2}:\\d{2}), )?(?P<msg>.*)` | line_format `{{ if .bmc_time }}{{ .bmc_time | replace \"-\" \" \" }}{{ else }}{{ .log_time }}{{ end }}`",
+          "expr": "{instance=~\"$instance_var\"} |~ \"ipmiseld\\\\[\\\\d+\\\\]\" | pattern `<raw>\"<_>\"` | regexp `(?P<log_time>\\w+\\s*\\d{1,2} \\d+:\\d+:\\d+) (?P<host>.+?) (?P<pid>\\S+): (SEL System Event: (?P<bmc_time>\\w{3}-\\d{2}-\\d{4}, \\d{2}:\\d{2}:\\d{2}), )?(?P<msg>.*)` | line_format `{{ if .bmc_time }}{{ .bmc_time | replace \"-\" \" \" }}{{ else }}{{ .log_time }}{{ end }}`",
           "queryType": "range",
           "refId": "A"
         }
@@ -520,6 +520,7 @@
           "type": "loki",
           "uid": "${lokids}"
         },
+        "allValue": ".+",
         "definition": "",
         "hide": 0,
         "includeAll": true,


### PR DESCRIPTION
- Changed `instance="$instance_var"` to `instance=~"$instance_var"`, so multi-value selection works correctly.
- Added `allValue: ".+"` to the Instance variable so "All" resolves to a compact regex instead of an expanded list, fixing the input size too long error at scale.

Closes #511
Closes #512