### PR TITLE
Update manual testing

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -3,6 +3,7 @@ import logging
 import os
 import platform
 from pathlib import Path
+from typing import List, Set
 
 import pytest
 from pytest_operator.plugin import OpsTest
@@ -135,7 +136,7 @@ def unit(app):
 
 
 @pytest.fixture()
-def resources() -> list[Resource]:
+def resources() -> List[Resource]:
     """Return list of Resource objects."""
     return [
         Resource(
@@ -174,7 +175,7 @@ def resources() -> list[Resource]:
 
 
 @pytest.fixture()
-def required_resources(resources: list[Resource], provided_collectors: set) -> list[Resource]:
+def required_resources(resources: List[Resource], provided_collectors: set) -> List[Resource]:
     """Return list of required resources to be attached as per hardware availability.
 
     Required resources will be empty if no collectors are provided.

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -3,7 +3,7 @@ import logging
 import os
 import platform
 from pathlib import Path
-from typing import List, Set
+from typing import List
 
 import pytest
 from pytest_operator.plugin import OpsTest

--- a/tests/functional/test_charm.py
+++ b/tests/functional/test_charm.py
@@ -143,6 +143,7 @@ async def test_required_resources(ops_test: OpsTest, required_resources):
 
 
 @pytest.mark.abort_on_fail
+@pytest.mark.skip_if_deployed
 async def test_cos_agent_relation(ops_test: OpsTest, provided_collectors):
     """Test adding relation with grafana-agent."""
     redfish_present = True if "redfish" in provided_collectors else False
@@ -321,7 +322,10 @@ class TestCharmWithHW:
                 app.set_config({"exporter-log-level": "RANDOM_LEVEL"}),
                 ops_test.model.wait_for_idle(apps=[APP_NAME], status="blocked", timeout=TIMEOUT),
             )
-            assert unit.workload_status_message == AppStatus.INVALID_CONFIG_EXPORTER_LOG_LEVEL
+            assert (
+                unit.workload_status_message.startswith("Invalid config:")
+                and "exporter-log-level" in unit.workload_status_message
+            )
 
         async with ops_test.fast_forward():
             await asyncio.gather(
@@ -738,6 +742,7 @@ class TestCharmWithHW:
 
 
 @pytest.mark.abort_on_fail
+@pytest.mark.skip_if_deployed
 async def test_on_remove_event(app, ops_test, nvidia_present):
     """Test _on_remove event cleans up the service on the host machine."""
     await asyncio.gather(

--- a/tests/functional/test_charm.py
+++ b/tests/functional/test_charm.py
@@ -143,7 +143,6 @@ async def test_required_resources(ops_test: OpsTest, required_resources):
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.skip_if_deployed
 async def test_cos_agent_relation(ops_test: OpsTest, provided_collectors):
     """Test adding relation with grafana-agent."""
     redfish_present = True if "redfish" in provided_collectors else False
@@ -742,7 +741,6 @@ class TestCharmWithHW:
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.skip_if_deployed
 async def test_on_remove_event(app, ops_test, nvidia_present):
     """Test _on_remove event cleans up the service on the host machine."""
     await asyncio.gather(

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -5,7 +5,7 @@ import re
 from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Dict, List, Optional
 
 import yaml
 from async_lru import alru_cache
@@ -80,7 +80,7 @@ async def get_hardware_exporter_config(ops_test, unit_name) -> dict:
 
 async def get_generic_exporter_metrics(
     ops_test, unit_name: str, port: int, metric_name: str
-) -> Optional[list[Metric]]:
+) -> Optional[List[Metric]]:
     """Return parsed prometheus metric output from Smartctl Exporter on unit.
 
     Raises MetricsFetchError if command to fetch metrics didn't execute successfully.
@@ -96,7 +96,7 @@ async def get_generic_exporter_metrics(
 @alru_cache
 async def get_hardware_exporter_metrics(
     ops_test, unit_name: str
-) -> Optional[dict[str, list[Metric]]]:
+) -> Optional[Dict[str, List[Metric]]]:
     """Return parsed prometheus metric output from Hardware Exporter on unit.
 
     Raises MetricsFetchError if command to fetch metrics didn't execute successfully.
@@ -127,7 +127,7 @@ async def assert_snap_installed(ops_test, unit_name: str, snap_name: str) -> boo
     return True
 
 
-def assert_metrics(metrics: list[Metric], expected_metric_values_map: dict[str, float]) -> bool:
+def assert_metrics(metrics: List[Metric], expected_metric_values_map: Dict[str, float]) -> bool:
     """Assert whether values in obtained list of metrics for a collector are as expected.
 
     Returns False if all expected metrics are not found in the list of provided metrics.
@@ -178,7 +178,7 @@ def _parse_single_metric(metric: str) -> Optional[Metric]:
         return None
 
 
-def parse_generic_exporter_metrics(metrics_input: str, metric_name: str) -> list[Metric]:
+def parse_generic_exporter_metrics(metrics_input: str, metric_name: str) -> List[Metric]:
     """Parse raw metrics and return a list of parsed Metric Objects.
 
     For example, parsing this metrics_input for metric_name "smartctl",
@@ -208,7 +208,7 @@ def parse_generic_exporter_metrics(metrics_input: str, metric_name: str) -> list
     return parsed_metrics
 
 
-def parse_hardware_exporter_metrics(metrics_input: str) -> dict[str, list[Metric]]:
+def parse_hardware_exporter_metrics(metrics_input: str) -> Dict[str, List[Metric]]:
     """Parse raw metrics and return dictionary of parsed Metric objects for each collector.
 
     For example, parsing this metrics_input,

--- a/tests/manual/README.md
+++ b/tests/manual/README.md
@@ -14,6 +14,9 @@ environment for testing Hardware Observer Operator with COS-Lite integrations.
 > The use of testflinger is restricted. External contributor will not be able to use Testflinger to allocate physical
 > machine. However, the terraform plan should still work if you somehow have access to a machine with hardware devices.
 
+> [NOTICE]
+> The terraform plan is using [MicroK8s charm][microk8s charm] to deploy the Kubernetes cluster directly on to the machine. However, the charm only supports Ubuntu 20.04 and 22.04, so the terraform plan will only work on machines with these versions. Future work for the terraform plan could include deploying the charm onto a 22.04 LXD VM instead - or better migrating to [Canonical K8s charm][canonical-k8s charm] since MicroK8s charm is no longer under active development.
+
 ## Quick start
 
 The overall workflow is outlined below:
@@ -35,3 +38,5 @@ terragrunt run-all apply
 ```
 
 [testflinger]: https://canonical-testflinger.readthedocs-hosted.com/en/latest/
+[microk8s charm]: https://charmhub.io/microk8s
+[canonical-k8s charm]: https://charmhub.io/k8s

--- a/tests/manual/etc/3_deploy_cos/main.tf
+++ b/tests/manual/etc/3_deploy_cos/main.tf
@@ -14,7 +14,7 @@ locals {
 }
 
 module "cos-lite-terraform" {
-  source = "git::https://github.com/canonical/snap-openstack.git//sunbeam-python/sunbeam/features/observability/etc/deploy-cos"
+  source = "git::https://github.com/canonical/snap-openstack.git//sunbeam-python/sunbeam/features/observability/etc/deploy-cos?ref=9e81465a91e068224077ad3f6fbf44705800139b"
 
   model      = local.cos_model_name
   cloud      = var.k8s_cloud_name

--- a/tests/manual/etc/4_deploy_grafana_agent/main.tf
+++ b/tests/manual/etc/4_deploy_grafana_agent/main.tf
@@ -10,7 +10,7 @@ terraform {
 provider "juju" {}
 
 module "grafana-agent" {
-  source = "git::https://github.com/canonical/snap-openstack.git//sunbeam-python/sunbeam/features/observability/etc/deploy-grafana-agent"
+  source = "git::https://github.com/canonical/snap-openstack.git//sunbeam-python/sunbeam/features/observability/etc/deploy-grafana-agent?ref=9e81465a91e068224077ad3f6fbf44705800139b"
 
   grafana-agent-base             = var.grafana_agent_base
   grafana-agent-channel          = "1/stable" # Can move back to latest/stable when the charm is updated

--- a/tests/manual/scripts/bootstrap.sh
+++ b/tests/manual/scripts/bootstrap.sh
@@ -28,12 +28,15 @@ if ! sudo modprobe nvidia; then
     echo "Failed to add nvidia kernel module"
 fi
 
-# Workaround for https://bugs.launchpad.net/juju/+bug/1964513
 USER=$(whoami)
-BRIDGE="br0"
-if [ -z "$(sudo --user $USER lxc storage list --format csv)" ]; then
-    echo 'Bootstrapping LXD'
-    cat <<EOF | sudo --user $USER lxd init --preseed
+UBUNTU_MAJOR=$(lsb_release -sr | cut -d. -f1)
+
+if [ "$UBUNTU_MAJOR" -lt 24 ]; then
+    # Workaround for https://bugs.launchpad.net/juju/+bug/1964513 (pre-Noble issue)
+    BRIDGE="br0"
+    if [ -z "$(sudo --user $USER lxc storage list --format csv)" ]; then
+        echo 'Bootstrapping LXD'
+        cat <<EOF | sudo --user $USER lxd init --preseed
 networks:
 - config:
     ipv4.address: auto
@@ -55,10 +58,18 @@ profiles:
       type: disk
   name: default
 EOF
+    fi
+else
+    BRIDGE="lxdbr0"
+    if [ -z "$(sudo --user $USER lxc storage list --format csv)" ]; then
+        echo 'Bootstrapping LXD'
+        sudo --user $USER lxd init --auto
+    fi
 fi
-BR0_ADDR=$(ip -4 -j a sho dev $BRIDGE | jq -r .[].addr_info[0].local)
-if [ -z "$BR0_ADDR" ]; then
-    echo 'Failed to configure LXD with bridge $BRIDGE'
+
+BRIDGE_ADDR=$(ip -4 -j a sho dev $BRIDGE | jq -r .[].addr_info[0].local)
+if [ -z "$BRIDGE_ADDR" ]; then
+    echo "Failed to configure LXD with bridge $BRIDGE"
     exit 1
 fi
 

--- a/tests/manual/scripts/bootstrap.sh
+++ b/tests/manual/scripts/bootstrap.sh
@@ -61,7 +61,7 @@ EOF
     fi
 else
     BRIDGE="lxdbr0"
-    if [ -z "$(sudo --user $USER lxc storage list --format csv)" ]; then
+    if ! ip link show "$BRIDGE" > /dev/null 2>&1; then
         echo 'Bootstrapping LXD'
         sudo --user $USER lxd init --auto
     fi

--- a/tests/manual/scripts/get-local-ip.sh
+++ b/tests/manual/scripts/get-local-ip.sh
@@ -1,3 +1,11 @@
 #!/bin/bash
 
-ip -4 -j a sho dev br0 | jq -r .[].addr_info[0].local
+UBUNTU_MAJOR=$(lsb_release -sr | cut -d. -f1)
+if [ "$UBUNTU_MAJOR" -lt 24 ]; then
+    # br0 bridges the physical NIC so its IP equals the external IP
+    ip -4 -j a sho dev br0 | jq -r .[].addr_info[0].local
+else
+    # On Noble+, lxdbr0 is NAT-only so its gateway IP doesn't match the machine's real IP;
+    # Here use the routing-preferred source address instead
+    ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc'
+fi


### PR DESCRIPTION
When provisioning the environment for manual testing as in `tests/manual`, I encountered several issues:
- In Noble, the [workaround](https://github.com/canonical/hardware-observer-operator/blob/73bd51ea1ca3a6c357be528072fcc395c3817d30/tests/manual/scripts/bootstrap.sh#L31) for lxd bridge will now cause the issue.  Seems like Juju controller can't get the IP from the renamed bridge. Let lxd auto init the bridge (back to default lxdbr0) makes the bootstrap work. 

- Terraform source modules for COS and grafana-agent deployment from snap-openstack are now pinned to a [newer juju tf version](https://github.com/canonical/snap-openstack/commit/0ff2a0d5896ac4ee2a93500851a8ea295518b66d), and cause conflict due to breaking changes. 

Fixes:
- Go back to default lxd init if release >= Noble
- Pin the upstream commit to match the current Terraform (later the manual test should change to a newer version of juju tf provider and update accordingly)
- Also, Microk8s charm doesn't support Noble so the tf plan will not work on Noble machine. I leave a notice then.

For running func tests:
- Update the assertion in `test_exporter_failed` to match current message. 
- Trival fix for running func test in Focal (python 3.8): 
    ```
      tests/functional/utils.py:83: in <module>
        ) -> Optional[list[Metric]]:
    E   TypeError: 'type' object is not subscriptable
    ```
   the fix won't break higher Python version but if we don't plan to test on Focal anymore then it can be opted-out to keep code cleaner.
