### PR TITLE
fix: release workflow need write permission

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,8 @@ jobs:
   release:
     needs: check
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
Release workflow need `contents=write` to create tag + gh release in the repo